### PR TITLE
the skeleton can run now!

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,11 @@
 ---
 # defaults file for RHEL7-CIS
+rhel7cis_section1: true
+rhel7cis_section2: true
+rhel7cis_section3: true
+rhel7cis_section4: true
+rhel7cis_section5: true
+rhel7cis_section6: true
+rhel7cis_section7: true
+rhel7cis_section8: true
+rhel7cis_section9: true

--- a/files/disable-rds.conf
+++ b/files/disable-rds.conf
@@ -1,0 +1,2 @@
+blacklist rds
+install rds /bin/true

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -1,5 +1,5 @@
 - name: "SCORED | 1.1.1 | AUDIT | Create Separate Partition for /tmp"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -11,7 +11,7 @@
       - rule_1.1.1
 
 - name: "SCORED | 1.1.1 | PATCH | Create Separate Partition for /tmp"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -19,7 +19,7 @@
       - rule_1.1.1
 
 - name: "SCORED | 1.1.2 | AUDIT | Set nodev option for /tmp Partition"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -31,7 +31,7 @@
       - rule_1.1.2
 
 - name: "SCORED | 1.1.2 | PATCH | Set nodev option for /tmp Partition"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -39,7 +39,7 @@
       - rule_1.1.2
 
 - name: "SCORED | 1.1.3 | AUDIT | Set nosuid option for /tmp Partition"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -51,7 +51,7 @@
       - rule_1.1.3
 
 - name: "SCORED | 1.1.3 | PATCH | Set nosuid option for /tmp Partition"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -59,7 +59,7 @@
       - rule_1.1.3
 
 - name: "SCORED | 1.1.4 | AUDIT | Set noexec option for /tmp Partition"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -71,7 +71,7 @@
       - rule_1.1.4
 
 - name: "SCORED | 1.1.4 | PATCH | Set noexec option for /tmp Partition"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -79,7 +79,7 @@
       - rule_1.1.4
 
 - name: "SCORED | 1.1.5 | AUDIT | Create Separate Partition for /var"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -91,7 +91,7 @@
       - rule_1.1.5
 
 - name: "SCORED | 1.1.5 | PATCH | Create Separate Partition for /var"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -99,7 +99,7 @@
       - rule_1.1.5
 
 - name: "SCORED | 1.1.6 | AUDIT | Bind Mount the /var/tmp directory to /tmp"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -111,7 +111,7 @@
       - rule_1.1.6
 
 - name: "SCORED | 1.1.6 | PATCH | Bind Mount the /var/tmp directory to /tmp"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -119,7 +119,7 @@
       - rule_1.1.6
 
 - name: "SCORED | 1.1.7 | AUDIT | Create Separate Partition for /var/log"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -131,7 +131,7 @@
       - rule_1.1.7
 
 - name: "SCORED | 1.1.7 | PATCH | Create Separate Partition for /var/log"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -139,7 +139,7 @@
       - rule_1.1.7
 
 - name: "SCORED | 1.1.8 | AUDIT | Create Separate Partition for /var/log/audit"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -151,7 +151,7 @@
       - rule_1.1.8
 
 - name: "SCORED | 1.1.8 | PATCH | Create Separate Partition for /var/log/audit"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -159,7 +159,7 @@
       - rule_1.1.8
 
 - name: "SCORED | 1.1.9 | AUDIT | Create Separate Partition for /home"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -171,7 +171,7 @@
       - rule_1.1.9
 
 - name: "SCORED | 1.1.9 | PATCH | Create Separate Partition for /home"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -179,7 +179,7 @@
       - rule_1.1.9
 
 - name: "SCORED | 1.1.10 | AUDIT | Add nodev Option to /home"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -191,7 +191,7 @@
       - rule_1.1.10
 
 - name: "SCORED | 1.1.10 | PATCH | Add nodev Option to /home"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -199,7 +199,7 @@
       - rule_1.1.10
 
 - name: "NOTSCORED | 1.1.11 | AUDIT | Add nodev Option to Removable Media Partitions"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -211,7 +211,7 @@
       - rule_1.1.11
 
 - name: "NOTSCORED | 1.1.11 | PATCH | Add nodev Option to Removable Media Partitions"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -219,7 +219,7 @@
       - rule_1.1.11
 
 - name: "NOTSCORED | 1.1.12 | AUDIT | Add noexec Option to Removable Media Partitions"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -231,7 +231,7 @@
       - rule_1.1.12
 
 - name: "NOTSCORED | 1.1.12 | PATCH | Add noexec Option to Removable Media Partitions"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -239,7 +239,7 @@
       - rule_1.1.12
 
 - name: "NOTSCORED | 1.1.13 | AUDIT | Add nosuid Option to Removable Media Partitions"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -251,7 +251,7 @@
       - rule_1.1.13
 
 - name: "NOTSCORED | 1.1.13 | PATCH | Add nosuid Option to Removable Media Partitions"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -259,7 +259,7 @@
       - rule_1.1.13
 
 - name: "SCORED | 1.1.14 | AUDIT | Add nodev Option to /dev/shm Partition"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -271,7 +271,7 @@
       - rule_1.1.14
 
 - name: "SCORED | 1.1.14 | PATCH | Add nodev Option to /dev/shm Partition"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -279,7 +279,7 @@
       - rule_1.1.14
 
 - name: "SCORED | 1.1.15 | AUDIT | Add nosuid Option to /dev/shm Partition"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -291,7 +291,7 @@
       - rule_1.1.15
 
 - name: "SCORED | 1.1.15 | PATCH | Add nosuid Option to /dev/shm Partition"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -299,7 +299,7 @@
       - rule_1.1.15
 
 - name: "SCORED | 1.1.16 | AUDIT | Add noexec Option to /dev/shm Partition"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -311,7 +311,7 @@
       - rule_1.1.16
 
 - name: "SCORED | 1.1.16 | PATCH | Add noexec Option to /dev/shm Partition"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -319,7 +319,7 @@
       - rule_1.1.16
 
 - name: "SCORED | 1.1.17 | AUDIT | Set Sticky Bit on All World-Writable Directories"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -331,7 +331,7 @@
       - rule_1.1.17
 
 - name: "SCORED | 1.1.17 | PATCH | Set Sticky Bit on All World-Writable Directories"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -339,7 +339,7 @@
       - rule_1.1.17
 
 - name: "NOTSCORED | 1.1.18 | AUDIT | Disable Mounting of cramfs Filesystems"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -350,14 +350,14 @@
       - rule_1.1.18
 
 - name: "NOTSCORED | 1.1.18 | PATCH | Disable Mounting of cramfs Filesystems"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.1.18
 
 - name: "NOTSCORED | 1.1.19 | AUDIT | Disable Mounting of freevxfs Filesystems"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -368,14 +368,14 @@
       - rule_1.1.19
 
 - name: "NOTSCORED | 1.1.19 | PATCH | Disable Mounting of freevxfs Filesystems"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.1.19
 
 - name: "NOTSCORED | 1.1.20 | AUDIT | Disable Mounting of jffs2 Filesystems"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -386,14 +386,14 @@
       - rule_1.1.20
 
 - name: "NOTSCORED | 1.1.20 | PATCH | Disable Mounting of jffs2 Filesystems"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.1.20
 
 - name: "NOTSCORED | 1.1.21 | AUDIT | Disable Mounting of hfs Filesystems"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -404,14 +404,14 @@
       - rule_1.1.21
 
 - name: "NOTSCORED | 1.1.21 | PATCH | Disable Mounting of hfs Filesystems"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.1.21
 
 - name: "NOTSCORED | 1.1.22 | AUDIT | Disable Mounting of hfsplus Filesystems"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -422,14 +422,14 @@
       - rule_1.1.22
 
 - name: "NOTSCORED | 1.1.22 | PATCH | Disable Mounting of hfsplus Filesystems"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.1.22
 
 - name: "NOTSCORED | 1.1.23 | AUDIT | Disable Mounting of squashfs Filesystems"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -440,14 +440,14 @@
       - rule_1.1.23
 
 - name: "NOTSCORED | 1.1.23 | PATCH | Disable Mounting of squashfs Filesystems"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.1.23
 
 - name: "NOTSCORED | 1.1.24 | AUDIT | Disable Mounting of udf Filesystems"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -458,14 +458,14 @@
       - rule_1.1.24
 
 - name: "NOTSCORED | 1.1.24 | PATCH | Disable Mounting of udf Filesystems"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.1.24
 
 - name: "NOTSCORED | 1.2.1 | AUDIT | Configure Connection to the RHN RPM Repositories"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -477,7 +477,7 @@
       - rule_1.2.1
 
 - name: "NOTSCORED | 1.2.1 | PATCH | Configure Connection to the RHN RPM Repositories"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -485,7 +485,7 @@
       - rule_1.2.1
 
 - name: "SCORED | 1.2.2 | AUDIT | Verify Red Hat GPG Key is Installed"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -497,7 +497,7 @@
       - rule_1.2.2
 
 - name: "SCORED | 1.2.2 | PATCH | Verify Red Hat GPG Key is Installed"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -505,7 +505,7 @@
       - rule_1.2.2
 
 - name: "SCORED | 1.2.3 | AUDIT | Verify that gpgcheck is Globally Activated"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -517,7 +517,7 @@
       - rule_1.2.3
 
 - name: "SCORED | 1.2.3 | PATCH | Verify that gpgcheck is Globally Activated"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -525,7 +525,7 @@
       - rule_1.2.3
 
 - name: "NOTSCORED | 1.2.4 | AUDIT | Disable the rhnsd Daemon"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -536,14 +536,14 @@
       - rule_1.2.4
 
 - name: "NOTSCORED | 1.2.4 | PATCH | Disable the rhnsd Daemon"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.2.4
 
 - name: "NOTSCORED | 1.2.5 | AUDIT | Obtain Software Package Updates with yum"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -555,7 +555,7 @@
       - rule_1.2.5
 
 - name: "NOTSCORED | 1.2.5 | PATCH | Obtain Software Package Updates with yum"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -563,7 +563,7 @@
       - rule_1.2.5
 
 - name: "NOTSCORED | 1.2.6 | AUDIT | Verify Package Integrity Using RPM"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -575,7 +575,7 @@
       - rule_1.2.6
 
 - name: "NOTSCORED | 1.2.6 | PATCH | Verify Package Integrity Using RPM"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -583,7 +583,7 @@
       - rule_1.2.6
 
 - name: "SCORED | 1.3.1 | AUDIT | Install AIDE"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -594,14 +594,14 @@
       - rule_1.3.1
 
 - name: "SCORED | 1.3.1 | PATCH | Install AIDE"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.3.1
 
 - name: "SCORED | 1.3.2 | AUDIT | Implement Periodic Execution of File Integrity"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -612,14 +612,14 @@
       - rule_1.3.2
 
 - name: "SCORED | 1.3.2 | PATCH | Implement Periodic Execution of File Integrity"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.3.2
 
 - name: "SCORED | 1.4.1 | AUDIT | Ensure SELinux is not disabled in /boot/grub2/grub.cfg"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -630,14 +630,14 @@
       - rule_1.4.1
 
 - name: "SCORED | 1.4.1 | PATCH | Ensure SELinux is not disabled in /boot/grub2/grub.cfg"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.4.1
 
 - name: "SCORED | 1.4.2 | AUDIT | Set the SELinux State"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -648,14 +648,14 @@
       - rule_1.4.2
 
 - name: "SCORED | 1.4.2 | PATCH | Set the SELinux State"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.4.2
 
 - name: "SCORED | 1.4.3 | AUDIT | Set the SELinux Policy"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -666,14 +666,14 @@
       - rule_1.4.3
 
 - name: "SCORED | 1.4.3 | PATCH | Set the SELinux Policy"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.4.3
 
 - name: "SCORED | 1.4.4 | AUDIT | Remove SETroubleshoot"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -684,14 +684,14 @@
       - rule_1.4.4
 
 - name: "SCORED | 1.4.4 | PATCH | Remove SETroubleshoot"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.4.4
 
 - name: "SCORED | 1.4.5 | AUDIT | Remove MCS Translation Service (mcstrans)"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -702,14 +702,14 @@
       - rule_1.4.5
 
 - name: "SCORED | 1.4.5 | PATCH | Remove MCS Translation Service (mcstrans)"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.4.5
 
 - name: "SCORED | 1.4.6 | AUDIT | Check for Unconfined Daemons"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -720,14 +720,14 @@
       - rule_1.4.6
 
 - name: "SCORED | 1.4.6 | PATCH | Check for Unconfined Daemons"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_1.4.6
 
 - name: "SCORED | 1.5.1 | AUDIT | Set User/Group Owner on /boot/grub2/grub.cfg"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -739,7 +739,7 @@
       - rule_1.5.1
 
 - name: "SCORED | 1.5.1 | PATCH | Set User/Group Owner on /boot/grub2/grub.cfg"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -747,7 +747,7 @@
       - rule_1.5.1
 
 - name: "SCORED | 1.5.2 | AUDIT | Set Permissions on /boot/grub2/grub.cfg"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -759,7 +759,7 @@
       - rule_1.5.2
 
 - name: "SCORED | 1.5.2 | PATCH | Set Permissions on /boot/grub2/grub.cfg"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -767,7 +767,7 @@
       - rule_1.5.2
 
 - name: "SCORED | 1.5.3 | AUDIT | Set Boot Loader Password"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -779,7 +779,7 @@
       - rule_1.5.3
 
 - name: "SCORED | 1.5.3 | PATCH | Set Boot Loader Password"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -787,7 +787,7 @@
       - rule_1.5.3
 
 - name: "SCORED | 1.6.1 | AUDIT | Restrict Core Dumps"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -799,7 +799,7 @@
       - rule_1.6.1
 
 - name: "SCORED | 1.6.1 | PATCH | Restrict Core Dumps"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -807,7 +807,7 @@
       - rule_1.6.1
 
 - name: "SCORED | 1.6.2 | AUDIT | Enable Randomized Virtual Memory Region Placement"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -819,7 +819,7 @@
       - rule_1.6.2
 
 - name: "SCORED | 1.6.2 | PATCH | Enable Randomized Virtual Memory Region Placement"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -827,7 +827,7 @@
       - rule_1.6.2
 
 - name: "NOTSCORED | 1.7 | AUDIT | Use the Latest OS Release"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -839,7 +839,7 @@
       - rule_1.7
 
 - name: "NOTSCORED | 1.7 | PATCH | Use the Latest OS Release"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -1,5 +1,5 @@
 - name: "SCORED | 2.1.1 | AUDIT | Remove telnet-server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -11,7 +11,7 @@
       - rule_2.1.1
 
 - name: "SCORED | 2.1.1 | PATCH | Remove telnet-server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -19,7 +19,7 @@
       - rule_2.1.1
 
 - name: "SCORED | 2.1.2 | AUDIT | Remove telnet Clients"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -31,7 +31,7 @@
       - rule_2.1.2
 
 - name: "SCORED | 2.1.2 | PATCH | Remove telnet Clients"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -39,7 +39,7 @@
       - rule_2.1.2
 
 - name: "SCORED | 2.1.3 | AUDIT | Remove rsh-server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -51,7 +51,7 @@
       - rule_2.1.3
 
 - name: "SCORED | 2.1.3 | PATCH | Remove rsh-server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -59,7 +59,7 @@
       - rule_2.1.3
 
 - name: "SCORED | 2.1.4 | AUDIT | Remove rsh"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -71,7 +71,7 @@
       - rule_2.1.4
 
 - name: "SCORED | 2.1.4 | PATCH | Remove rsh"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -79,7 +79,7 @@
       - rule_2.1.4
 
 - name: "SCORED | 2.1.5 | AUDIT | Remove NIS Client"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -91,7 +91,7 @@
       - rule_2.1.5
 
 - name: "SCORED | 2.1.5 | PATCH | Remove NIS Client"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -99,7 +99,7 @@
       - rule_2.1.5
 
 - name: "SCORED | 2.1.6 | AUDIT | Remove NIS Server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -111,7 +111,7 @@
       - rule_2.1.6
 
 - name: "SCORED | 2.1.6 | PATCH | Remove NIS Server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -119,7 +119,7 @@
       - rule_2.1.6
 
 - name: "SCORED | 2.1.7 | AUDIT | Remove tftp"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -131,7 +131,7 @@
       - rule_2.1.7
 
 - name: "SCORED | 2.1.7 | PATCH | Remove tftp"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -139,7 +139,7 @@
       - rule_2.1.7
 
 - name: "SCORED | 2.1.8 | AUDIT | Remove tftp-server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -151,7 +151,7 @@
       - rule_2.1.8
 
 - name: "SCORED | 2.1.8 | PATCH | Remove tftp-server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -159,7 +159,7 @@
       - rule_2.1.8
 
 - name: "SCORED | 2.1.9 | AUDIT | Remove talk"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -171,7 +171,7 @@
       - rule_2.1.9
 
 - name: "SCORED | 2.1.9 | PATCH | Remove talk"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -179,7 +179,7 @@
       - rule_2.1.9
 
 - name: "SCORED | 2.1.10 | AUDIT | Remove talk-server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -191,7 +191,7 @@
       - rule_2.1.10
 
 - name: "SCORED | 2.1.10 | PATCH | Remove talk-server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -199,7 +199,7 @@
       - rule_2.1.10
 
 - name: "SCORED | 2.1.11 | AUDIT | Remove xinetd"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -210,14 +210,14 @@
       - rule_2.1.11
 
 - name: "SCORED | 2.1.11 | PATCH | Remove xinetd"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_2.1.11
 
 - name: "SCORED | 2.1.12 | AUDIT | Disable chargen-dgram"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -229,7 +229,7 @@
       - rule_2.1.12
 
 - name: "SCORED | 2.1.12 | PATCH | Disable chargen-dgram"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -237,7 +237,7 @@
       - rule_2.1.12
 
 - name: "SCORED | 2.1.13 | AUDIT | Disable chargen-stream"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -249,7 +249,7 @@
       - rule_2.1.13
 
 - name: "SCORED | 2.1.13 | PATCH | Disable chargen-stream"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -257,7 +257,7 @@
       - rule_2.1.13
 
 - name: "SCORED | 2.1.14 | AUDIT | Disable daytime-dgram"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -269,7 +269,7 @@
       - rule_2.1.14
 
 - name: "SCORED | 2.1.14 | PATCH | Disable daytime-dgram"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -277,7 +277,7 @@
       - rule_2.1.14
 
 - name: "SCORED | 2.1.15 | AUDIT | Disable daytime-stream"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -289,7 +289,7 @@
       - rule_2.1.15
 
 - name: "SCORED | 2.1.15 | PATCH | Disable daytime-stream"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -297,7 +297,7 @@
       - rule_2.1.15
 
 - name: "SCORED | 2.1.16 | AUDIT | Disable echo-dgram"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -309,7 +309,7 @@
       - rule_2.1.16
 
 - name: "SCORED | 2.1.16 | PATCH | Disable echo-dgram"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -317,7 +317,7 @@
       - rule_2.1.16
 
 - name: "SCORED | 2.1.17 | AUDIT | Disable echo-stream"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -329,7 +329,7 @@
       - rule_2.1.17
 
 - name: "SCORED | 2.1.17 | PATCH | Disable echo-stream"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -337,7 +337,7 @@
       - rule_2.1.17
 
 - name: "SCORED | 2.1.18 | AUDIT | Disable tcpmux-server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -349,7 +349,7 @@
       - rule_2.1.18
 
 - name: "SCORED | 2.1.18 | PATCH | Disable tcpmux-server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -1,5 +1,5 @@
 - name: "SCORED | 2.1.1 | AUDIT | Remove telnet-server"
-  command: /bin/true
+  command: rpm -q telnet-server
   register: result
   always_run: yes
   changed_when: no
@@ -11,7 +11,9 @@
       - rule_2.1.1
 
 - name: "SCORED | 2.1.1 | PATCH | Remove telnet-server"
-  command: /bin/true
+  yum:
+    name: telnet-server
+    state: absent
   tags:
       - level1
       - level2
@@ -19,7 +21,7 @@
       - rule_2.1.1
 
 - name: "SCORED | 2.1.2 | AUDIT | Remove telnet Clients"
-  command: /bin/true
+  command: rpm -q telnet
   register: result
   always_run: yes
   changed_when: no
@@ -31,7 +33,9 @@
       - rule_2.1.2
 
 - name: "SCORED | 2.1.2 | PATCH | Remove telnet Clients"
-  command: /bin/true
+  yum:
+    name: telnet
+    state: absent
   tags:
       - level1
       - level2
@@ -39,7 +43,7 @@
       - rule_2.1.2
 
 - name: "SCORED | 2.1.3 | AUDIT | Remove rsh-server"
-  command: /bin/true
+  command: rpm -q rsh-server
   register: result
   always_run: yes
   changed_when: no
@@ -51,7 +55,9 @@
       - rule_2.1.3
 
 - name: "SCORED | 2.1.3 | PATCH | Remove rsh-server"
-  command: /bin/true
+  yum:
+    name: rsh-server
+    state: absent
   tags:
       - level1
       - level2
@@ -59,7 +65,7 @@
       - rule_2.1.3
 
 - name: "SCORED | 2.1.4 | AUDIT | Remove rsh"
-  command: /bin/true
+  command: rpm -q rsh
   register: result
   always_run: yes
   changed_when: no
@@ -71,7 +77,9 @@
       - rule_2.1.4
 
 - name: "SCORED | 2.1.4 | PATCH | Remove rsh"
-  command: /bin/true
+  yum:
+    name: rsh
+    state: absent
   tags:
       - level1
       - level2
@@ -79,7 +87,7 @@
       - rule_2.1.4
 
 - name: "SCORED | 2.1.5 | AUDIT | Remove NIS Client"
-  command: /bin/true
+  command: rpm -q yp-tools
   register: result
   always_run: yes
   changed_when: no
@@ -91,7 +99,9 @@
       - rule_2.1.5
 
 - name: "SCORED | 2.1.5 | PATCH | Remove NIS Client"
-  command: /bin/true
+    yum:
+    name: yp-tools
+    state: absent
   tags:
       - level1
       - level2
@@ -99,7 +109,7 @@
       - rule_2.1.5
 
 - name: "SCORED | 2.1.6 | AUDIT | Remove NIS Server"
-  command: /bin/true
+  command: rpm -q ypserv
   register: result
   always_run: yes
   changed_when: no
@@ -111,7 +121,9 @@
       - rule_2.1.6
 
 - name: "SCORED | 2.1.6 | PATCH | Remove NIS Server"
-  command: /bin/true
+  yum:
+    name: ypserv
+    state: absent
   tags:
       - level1
       - level2
@@ -119,7 +131,7 @@
       - rule_2.1.6
 
 - name: "SCORED | 2.1.7 | AUDIT | Remove tftp"
-  command: /bin/true
+  command: rpm -q tftp
   register: result
   always_run: yes
   changed_when: no
@@ -131,7 +143,9 @@
       - rule_2.1.7
 
 - name: "SCORED | 2.1.7 | PATCH | Remove tftp"
-  command: /bin/true
+  yum:
+      name: tftp
+      state: absent
   tags:
       - level1
       - level2
@@ -139,7 +153,7 @@
       - rule_2.1.7
 
 - name: "SCORED | 2.1.8 | AUDIT | Remove tftp-server"
-  command: /bin/true
+  command: rpm -q tftp-server
   register: result
   always_run: yes
   changed_when: no
@@ -151,7 +165,9 @@
       - rule_2.1.8
 
 - name: "SCORED | 2.1.8 | PATCH | Remove tftp-server"
-  command: /bin/true
+  yum:
+      name: tftp-server
+      state: absent
   tags:
       - level1
       - level2
@@ -159,7 +175,7 @@
       - rule_2.1.8
 
 - name: "SCORED | 2.1.9 | AUDIT | Remove talk"
-  command: /bin/true
+  command: rpm -q talk
   register: result
   always_run: yes
   changed_when: no
@@ -171,7 +187,9 @@
       - rule_2.1.9
 
 - name: "SCORED | 2.1.9 | PATCH | Remove talk"
-  command: /bin/true
+  yum:
+    name: talk
+    state: absent
   tags:
       - level1
       - level2
@@ -179,7 +197,7 @@
       - rule_2.1.9
 
 - name: "SCORED | 2.1.10 | AUDIT | Remove talk-server"
-  command: /bin/true
+  command: rpm -q talk-server
   register: result
   always_run: yes
   changed_when: no
@@ -191,7 +209,9 @@
       - rule_2.1.10
 
 - name: "SCORED | 2.1.10 | PATCH | Remove talk-server"
-  command: /bin/true
+  yum:
+    name: talk-server
+    state: absent
   tags:
       - level1
       - level2
@@ -199,7 +219,7 @@
       - rule_2.1.10
 
 - name: "SCORED | 2.1.11 | AUDIT | Remove xinetd"
-  command: /bin/true
+  command: rpm -q xinetd
   register: result
   always_run: yes
   changed_when: no
@@ -210,7 +230,9 @@
       - rule_2.1.11
 
 - name: "SCORED | 2.1.11 | PATCH | Remove xinetd"
-  command: /bin/true
+    yum:
+    name: xinetd
+    state: absent
   tags:
       - level2
       - patch

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -251,7 +251,9 @@
       - rule_2.1.12
 
 - name: "SCORED | 2.1.12 | PATCH | Disable chargen-dgram"
-  command: chkconfig chargen-dgram off
+  yum:
+    name: xinetd
+    state: absent
   tags:
       - level1
       - level2
@@ -271,7 +273,9 @@
       - rule_2.1.13
 
 - name: "SCORED | 2.1.13 | PATCH | Disable chargen-stream"
-  command: chkconfig chargen-stream off
+  yum:
+    name: xinetd
+    state: absent
   tags:
       - level1
       - level2
@@ -291,7 +295,9 @@
       - rule_2.1.14
 
 - name: "SCORED | 2.1.14 | PATCH | Disable daytime-dgram"
-  command: chkconfig daytime-dgram off
+  yum:
+    name: xinetd
+    state: absent
   tags:
       - level1
       - level2
@@ -311,7 +317,9 @@
       - rule_2.1.15
 
 - name: "SCORED | 2.1.15 | PATCH | Disable daytime-stream"
-  command: chkconfig daytime-stream off
+  yum:
+    name: xinetd
+    state: absent
   tags:
       - level1
       - level2
@@ -331,7 +339,9 @@
       - rule_2.1.16
 
 - name: "SCORED | 2.1.16 | PATCH | Disable echo-dgram"
-  command: chkconfig echo-dgram off
+  yum:
+    name: xinetd
+    state: absent
   tags:
       - level1
       - level2
@@ -351,7 +361,9 @@
       - rule_2.1.17
 
 - name: "SCORED | 2.1.17 | PATCH | Disable echo-stream"
-  command: chkconfig echo-stream off
+  yum:
+    name: xinetd
+    state: absent
   tags:
       - level1
       - level2
@@ -371,7 +383,9 @@
       - rule_2.1.18
 
 - name: "SCORED | 2.1.18 | PATCH | Disable tcpmux-server"
-  command: chkconfig tcpmux-server off
+  yum:
+    name: xinetd
+    state: absent
   tags:
       - level1
       - level2

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -99,7 +99,7 @@
       - rule_2.1.5
 
 - name: "SCORED | 2.1.5 | PATCH | Remove NIS Client"
-    yum:
+  yum:
     name: yp-tools
     state: absent
   tags:
@@ -230,7 +230,7 @@
       - rule_2.1.11
 
 - name: "SCORED | 2.1.11 | PATCH | Remove xinetd"
-    yum:
+  yum:
     name: xinetd
     state: absent
   tags:
@@ -239,7 +239,7 @@
       - rule_2.1.11
 
 - name: "SCORED | 2.1.12 | AUDIT | Disable chargen-dgram"
-  command: /bin/true
+  shell: chkconfig --list chargen-dgram | grep 'off'
   register: result
   always_run: yes
   changed_when: no
@@ -251,7 +251,7 @@
       - rule_2.1.12
 
 - name: "SCORED | 2.1.12 | PATCH | Disable chargen-dgram"
-  command: /bin/true
+  command: chkconfig chargen-dgram off
   tags:
       - level1
       - level2
@@ -259,7 +259,7 @@
       - rule_2.1.12
 
 - name: "SCORED | 2.1.13 | AUDIT | Disable chargen-stream"
-  command: /bin/true
+  shell: chkconfig --list chargen-stream | grep 'off'
   register: result
   always_run: yes
   changed_when: no
@@ -271,7 +271,7 @@
       - rule_2.1.13
 
 - name: "SCORED | 2.1.13 | PATCH | Disable chargen-stream"
-  command: /bin/true
+  command: chkconfig chargen-stream off
   tags:
       - level1
       - level2
@@ -279,7 +279,7 @@
       - rule_2.1.13
 
 - name: "SCORED | 2.1.14 | AUDIT | Disable daytime-dgram"
-  command: /bin/true
+  shell: chkconfig --list daytime-dgram | grep 'off'
   register: result
   always_run: yes
   changed_when: no
@@ -291,7 +291,7 @@
       - rule_2.1.14
 
 - name: "SCORED | 2.1.14 | PATCH | Disable daytime-dgram"
-  command: /bin/true
+  command: chkconfig daytime-dgram off
   tags:
       - level1
       - level2
@@ -299,7 +299,7 @@
       - rule_2.1.14
 
 - name: "SCORED | 2.1.15 | AUDIT | Disable daytime-stream"
-  command: /bin/true
+  shell: chkconfig --list daytime-stream | grep 'off'
   register: result
   always_run: yes
   changed_when: no
@@ -311,7 +311,7 @@
       - rule_2.1.15
 
 - name: "SCORED | 2.1.15 | PATCH | Disable daytime-stream"
-  command: /bin/true
+  command: chkconfig daytime-stream off
   tags:
       - level1
       - level2
@@ -319,7 +319,7 @@
       - rule_2.1.15
 
 - name: "SCORED | 2.1.16 | AUDIT | Disable echo-dgram"
-  command: /bin/true
+  shell: chkconfig --list echo-dgram | grep 'off'
   register: result
   always_run: yes
   changed_when: no
@@ -331,7 +331,7 @@
       - rule_2.1.16
 
 - name: "SCORED | 2.1.16 | PATCH | Disable echo-dgram"
-  command: /bin/true
+  command: chkconfig echo-dgram off
   tags:
       - level1
       - level2
@@ -339,7 +339,7 @@
       - rule_2.1.16
 
 - name: "SCORED | 2.1.17 | AUDIT | Disable echo-stream"
-  command: /bin/true
+  shell: chkconfig --list echo-stream | grep 'off'
   register: result
   always_run: yes
   changed_when: no
@@ -351,7 +351,7 @@
       - rule_2.1.17
 
 - name: "SCORED | 2.1.17 | PATCH | Disable echo-stream"
-  command: /bin/true
+  command: chkconfig echo-stream off
   tags:
       - level1
       - level2
@@ -359,7 +359,7 @@
       - rule_2.1.17
 
 - name: "SCORED | 2.1.18 | AUDIT | Disable tcpmux-server"
-  command: /bin/true
+  shell: chkconfig --list tcpmux-server | grep 'off'
   register: result
   always_run: yes
   changed_when: no
@@ -371,7 +371,7 @@
       - rule_2.1.18
 
 - name: "SCORED | 2.1.18 | PATCH | Disable tcpmux-server"
-  command: /bin/true
+  command: chkconfig tcpmux-server off
   tags:
       - level1
       - level2

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -1,5 +1,5 @@
 - name: "SCORED | 3.1 | AUDIT | Set Daemon umask"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -11,7 +11,7 @@
       - rule_3.1
 
 - name: "SCORED | 3.1 | PATCH | Set Daemon umask"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -19,7 +19,7 @@
       - rule_3.1
 
 - name: "SCORED | 3.2 | AUDIT | Remove the X Window System"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -31,7 +31,7 @@
       - rule_3.2
 
 - name: "SCORED | 3.2 | PATCH | Remove the X Window System"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -39,7 +39,7 @@
       - rule_3.2
 
 - name: "SCORED | 3.3 | AUDIT | Disable Avahi Server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -51,7 +51,7 @@
       - rule_3.3
 
 - name: "SCORED | 3.3 | PATCH | Disable Avahi Server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -59,7 +59,7 @@
       - rule_3.3
 
 - name: "NOTSCORED | 3.4 | AUDIT | Disable Print Server - CUPS"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -71,7 +71,7 @@
       - rule_3.4
 
 - name: "NOTSCORED | 3.4 | PATCH | Disable Print Server - CUPS"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -79,7 +79,7 @@
       - rule_3.4
 
 - name: "SCORED | 3.5 | AUDIT | Remove DHCP Server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -91,7 +91,7 @@
       - rule_3.5
 
 - name: "SCORED | 3.5 | PATCH | Remove DHCP Server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -99,7 +99,7 @@
       - rule_3.5
 
 - name: "SCORED | 3.6 | AUDIT | Configure Network Time Protocol (NTP)"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -111,7 +111,7 @@
       - rule_3.6
 
 - name: "SCORED | 3.6 | PATCH | Configure Network Time Protocol (NTP)"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -119,7 +119,7 @@
       - rule_3.6
 
 - name: "NOTSCORED | 3.7 | AUDIT | Remove LDAP"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -131,7 +131,7 @@
       - rule_3.7
 
 - name: "NOTSCORED | 3.7 | PATCH | Remove LDAP"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -139,7 +139,7 @@
       - rule_3.7
 
 - name: "NOTSCORED | 3.8 | AUDIT | Disable NFS and RPC"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -151,7 +151,7 @@
       - rule_3.8
 
 - name: "NOTSCORED | 3.8 | PATCH | Disable NFS and RPC"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -159,7 +159,7 @@
       - rule_3.8
 
 - name: "NOTSCORED | 3.9 | AUDIT | Remove DNS Server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -171,7 +171,7 @@
       - rule_3.9
 
 - name: "NOTSCORED | 3.9 | PATCH | Remove DNS Server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -179,7 +179,7 @@
       - rule_3.9
 
 - name: "NOTSCORED | 3.10 | AUDIT | Remove FTP Server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -191,7 +191,7 @@
       - rule_3.10
 
 - name: "NOTSCORED | 3.10 | PATCH | Remove FTP Server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -199,7 +199,7 @@
       - rule_3.10
 
 - name: "NOTSCORED | 3.11 | AUDIT | Remove HTTP Server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -211,7 +211,7 @@
       - rule_3.11
 
 - name: "NOTSCORED | 3.11 | PATCH | Remove HTTP Server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -219,7 +219,7 @@
       - rule_3.11
 
 - name: "NOTSCORED | 3.12 | AUDIT | Remove Dovecot (IMAP and POP3 services)"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -231,7 +231,7 @@
       - rule_3.12
 
 - name: "NOTSCORED | 3.12 | PATCH | Remove Dovecot (IMAP and POP3 services)"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -239,7 +239,7 @@
       - rule_3.12
 
 - name: "NOTSCORED | 3.13 | AUDIT | Remove Samba"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -251,7 +251,7 @@
       - rule_3.13
 
 - name: "NOTSCORED | 3.13 | PATCH | Remove Samba"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -259,7 +259,7 @@
       - rule_3.13
 
 - name: "NOTSCORED | 3.14 | AUDIT | Remove HTTP Proxy Server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -271,7 +271,7 @@
       - rule_3.14
 
 - name: "NOTSCORED | 3.14 | PATCH | Remove HTTP Proxy Server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -279,7 +279,7 @@
       - rule_3.14
 
 - name: "NOTSCORED | 3.15 | AUDIT | Remove SNMP Server"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -291,7 +291,7 @@
       - rule_3.15
 
 - name: "NOTSCORED | 3.15 | PATCH | Remove SNMP Server"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -299,7 +299,7 @@
       - rule_3.15
 
 - name: "SCORED | 3.16 | AUDIT | Configure Mail Transfer Agent for Local-Only Mode"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -311,7 +311,7 @@
       - rule_3.16
 
 - name: "SCORED | 3.16 | PATCH | Configure Mail Transfer Agent for Local-Only Mode"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -1,5 +1,5 @@
 - name: "SCORED | 3.1 | AUDIT | Set Daemon umask"
-  command: /bin/true
+  command: grep umask /etc/sysconfig/init
   register: result
   always_run: yes
   changed_when: no
@@ -11,7 +11,11 @@
       - rule_3.1
 
 - name: "SCORED | 3.1 | PATCH | Set Daemon umask"
-  command: /bin/true
+  lineinfile:
+      dest=/etc/sysconfig/init
+      regexp='^umask'
+      line='umask 027'
+      state=present
   tags:
       - level1
       - level2
@@ -19,7 +23,7 @@
       - rule_3.1
 
 - name: "SCORED | 3.2 | AUDIT | Remove the X Window System"
-  command: /bin/true
+  command: rpm -q xorg-x11-server-common
   register: result
   always_run: yes
   changed_when: no
@@ -31,7 +35,9 @@
       - rule_3.2
 
 - name: "SCORED | 3.2 | PATCH | Remove the X Window System"
-  command: /bin/true
+  yum:
+      name=xorg-x11-server-common
+      state=absent
   tags:
       - level1
       - level2
@@ -71,7 +77,9 @@
       - rule_3.4
 
 - name: "NOTSCORED | 3.4 | PATCH | Disable Print Server - CUPS"
-  command: /bin/true
+  yum:
+      name=cups
+      state=absent
   tags:
       - level1
       - level2
@@ -79,7 +87,7 @@
       - rule_3.4
 
 - name: "SCORED | 3.5 | AUDIT | Remove DHCP Server"
-  command: /bin/true
+  command: rpm -q dhcp
   register: result
   always_run: yes
   changed_when: no
@@ -91,7 +99,9 @@
       - rule_3.5
 
 - name: "SCORED | 3.5 | PATCH | Remove DHCP Server"
-  command: /bin/true
+  yum:
+      name=dhcp
+      state=absent
   tags:
       - level1
       - level2
@@ -99,7 +109,7 @@
       - rule_3.5
 
 - name: "SCORED | 3.6 | AUDIT | Configure Network Time Protocol (NTP)"
-  command: /bin/true
+  command: grep "restrict default" /etc/ntp.conf
   register: result
   always_run: yes
   changed_when: no
@@ -111,7 +121,47 @@
       - rule_3.6
 
 - name: "SCORED | 3.6 | PATCH | Configure Network Time Protocol (NTP)"
-  command: /bin/true
+  lineinfile:
+      dest=/etc/ntp.conf
+      regexp='^restrict default'
+      line='restrict default kod nomodify notrap nopeer noquery'
+      state=present
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_3.6
+
+- name: "SCORED | 3.6 | AUDIT | Configure Network Time Protocol (NTP)"
+  command: grep "restrict -6 default" /etc/ntp.conf
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_3.6
+
+- name: "SCORED | 3.6 | PATCH | Configure Network Time Protocol (NTP)"
+  lineinfile:
+      dest=/etc/ntp.conf
+      regexp='^restrict -6 default'
+      line='restrict -6 default kod nomodify notrap nopeer noquery'
+      state=present
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_3.6
+
+- name: "SCORED | 3.6 | PATCH | Configure Network Time Protocol (NTP)"
+  lineinfile:
+      dest=/etc/sysconfig/ntpd
+      regexp='^OPTIONS'
+      line='OPTIONS="-u ntp:ntp"'
+      state=present
   tags:
       - level1
       - level2
@@ -119,7 +169,7 @@
       - rule_3.6
 
 - name: "NOTSCORED | 3.7 | AUDIT | Remove LDAP"
-  command: /bin/true
+  command: rpm -q openldap-servers
   register: result
   always_run: yes
   changed_when: no
@@ -131,7 +181,9 @@
       - rule_3.7
 
 - name: "NOTSCORED | 3.7 | PATCH | Remove LDAP"
-  command: /bin/true
+  yum:
+      name=openldap-servers
+      state=absent
   tags:
       - level1
       - level2
@@ -159,7 +211,7 @@
       - rule_3.8
 
 - name: "NOTSCORED | 3.9 | AUDIT | Remove DNS Server"
-  command: /bin/true
+  command: rpm -q bind
   register: result
   always_run: yes
   changed_when: no
@@ -171,7 +223,9 @@
       - rule_3.9
 
 - name: "NOTSCORED | 3.9 | PATCH | Remove DNS Server"
-  command: /bin/true
+  yum:
+      name=bind
+      state=absent
   tags:
       - level1
       - level2
@@ -179,7 +233,7 @@
       - rule_3.9
 
 - name: "NOTSCORED | 3.10 | AUDIT | Remove FTP Server"
-  command: /bin/true
+  command: rpm -q vsftpd
   register: result
   always_run: yes
   changed_when: no
@@ -191,7 +245,9 @@
       - rule_3.10
 
 - name: "NOTSCORED | 3.10 | PATCH | Remove FTP Server"
-  command: /bin/true
+  yum:
+      name=vsftpd
+      state=absent
   tags:
       - level1
       - level2
@@ -199,7 +255,7 @@
       - rule_3.10
 
 - name: "NOTSCORED | 3.11 | AUDIT | Remove HTTP Server"
-  command: /bin/true
+  command: rpm -q httpd
   register: result
   always_run: yes
   changed_when: no
@@ -211,7 +267,9 @@
       - rule_3.11
 
 - name: "NOTSCORED | 3.11 | PATCH | Remove HTTP Server"
-  command: /bin/true
+  yum:
+      name=httpd
+      state=absent
   tags:
       - level1
       - level2
@@ -219,7 +277,7 @@
       - rule_3.11
 
 - name: "NOTSCORED | 3.12 | AUDIT | Remove Dovecot (IMAP and POP3 services)"
-  command: /bin/true
+  command: rpm -q dovecot
   register: result
   always_run: yes
   changed_when: no
@@ -231,7 +289,9 @@
       - rule_3.12
 
 - name: "NOTSCORED | 3.12 | PATCH | Remove Dovecot (IMAP and POP3 services)"
-  command: /bin/true
+  yum:
+      name=dovecot
+      state=absent
   tags:
       - level1
       - level2
@@ -239,7 +299,7 @@
       - rule_3.12
 
 - name: "NOTSCORED | 3.13 | AUDIT | Remove Samba"
-  command: /bin/true
+  command: rpm -q samba
   register: result
   always_run: yes
   changed_when: no
@@ -251,7 +311,9 @@
       - rule_3.13
 
 - name: "NOTSCORED | 3.13 | PATCH | Remove Samba"
-  command: /bin/true
+  yum:
+      name=samba
+      state=absent
   tags:
       - level1
       - level2
@@ -259,7 +321,7 @@
       - rule_3.13
 
 - name: "NOTSCORED | 3.14 | AUDIT | Remove HTTP Proxy Server"
-  command: /bin/true
+  command: rpm -q squid
   register: result
   always_run: yes
   changed_when: no
@@ -271,7 +333,9 @@
       - rule_3.14
 
 - name: "NOTSCORED | 3.14 | PATCH | Remove HTTP Proxy Server"
-  command: /bin/true
+  yum:
+      name=squid
+      state=absent
   tags:
       - level1
       - level2
@@ -279,7 +343,7 @@
       - rule_3.14
 
 - name: "NOTSCORED | 3.15 | AUDIT | Remove SNMP Server"
-  command: /bin/true
+  command: rpm -q net-snmp
   register: result
   always_run: yes
   changed_when: no
@@ -291,7 +355,9 @@
       - rule_3.15
 
 - name: "NOTSCORED | 3.15 | PATCH | Remove SNMP Server"
-  command: /bin/true
+  yum:
+      name=net-snmp
+      state=absent
   tags:
       - level1
       - level2
@@ -299,7 +365,7 @@
       - rule_3.15
 
 - name: "SCORED | 3.16 | AUDIT | Configure Mail Transfer Agent for Local-Only Mode"
-  command: /bin/true
+  command: netstat -ant | grep LIST | grep ":25[[:space:]]"|grep 127.0.0.1
   register: result
   always_run: yes
   changed_when: no
@@ -311,7 +377,11 @@
       - rule_3.16
 
 - name: "SCORED | 3.16 | PATCH | Configure Mail Transfer Agent for Local-Only Mode"
-  command: /bin/true
+  lineinfile:
+      dest=/etc/postfix/main.cf
+      regexp='^inet_interfaces'
+      line='inet_interfaces = localhost'
+      state=present
   tags:
       - level1
       - level2

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -1,5 +1,5 @@
 - name: "SCORED | 4.1.1 | AUDIT | Disable IP Forwarding"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -11,7 +11,7 @@
       - rule_4.1.1
 
 - name: "SCORED | 4.1.1 | PATCH | Disable IP Forwarding"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -19,7 +19,7 @@
       - rule_4.1.1
 
 - name: "SCORED | 4.1.2 | AUDIT | Disable Send Packet Redirects"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -31,7 +31,7 @@
       - rule_4.1.2
 
 - name: "SCORED | 4.1.2 | PATCH | Disable Send Packet Redirects"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -39,7 +39,7 @@
       - rule_4.1.2
 
 - name: "SCORED | 4.2.1 | AUDIT | Disable Source Routed Packet Acceptance"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -51,7 +51,7 @@
       - rule_4.2.1
 
 - name: "SCORED | 4.2.1 | PATCH | Disable Source Routed Packet Acceptance"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -59,7 +59,7 @@
       - rule_4.2.1
 
 - name: "SCORED | 4.2.2 | AUDIT | Disable ICMP Redirect Acceptance"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -71,7 +71,7 @@
       - rule_4.2.2
 
 - name: "SCORED | 4.2.2 | PATCH | Disable ICMP Redirect Acceptance"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -79,7 +79,7 @@
       - rule_4.2.2
 
 - name: "SCORED | 4.2.3 | AUDIT | Disable Secure ICMP Redirect Acceptance"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -90,14 +90,14 @@
       - rule_4.2.3
 
 - name: "SCORED | 4.2.3 | PATCH | Disable Secure ICMP Redirect Acceptance"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_4.2.3
 
 - name: "SCORED | 4.2.4 | AUDIT | Log Suspicious Packets"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -109,7 +109,7 @@
       - rule_4.2.4
 
 - name: "SCORED | 4.2.4 | PATCH | Log Suspicious Packets"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -117,7 +117,7 @@
       - rule_4.2.4
 
 - name: "SCORED | 4.2.5 | AUDIT | Enable Ignore Broadcast Requests"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -129,7 +129,7 @@
       - rule_4.2.5
 
 - name: "SCORED | 4.2.5 | PATCH | Enable Ignore Broadcast Requests"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -137,7 +137,7 @@
       - rule_4.2.5
 
 - name: "SCORED | 4.2.6 | AUDIT | Enable Bad Error Message Protection"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -149,7 +149,7 @@
       - rule_4.2.6
 
 - name: "SCORED | 4.2.6 | PATCH | Enable Bad Error Message Protection"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -157,7 +157,7 @@
       - rule_4.2.6
 
 - name: "SCORED | 4.2.7 | AUDIT | Enable RFC-recommended Source Route Validation"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -168,14 +168,14 @@
       - rule_4.2.7
 
 - name: "SCORED | 4.2.7 | PATCH | Enable RFC-recommended Source Route Validation"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_4.2.7
 
 - name: "SCORED | 4.2.8 | AUDIT | Enable TCP SYN Cookies"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -187,7 +187,7 @@
       - rule_4.2.8
 
 - name: "SCORED | 4.2.8 | PATCH | Enable TCP SYN Cookies"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -195,7 +195,7 @@
       - rule_4.2.8
 
 - name: "NOTSCORED | 4.3.1 | AUDIT | Deactivate Wireless Interfaces"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -207,7 +207,7 @@
       - rule_4.3.1
 
 - name: "NOTSCORED | 4.3.1 | PATCH | Deactivate Wireless Interfaces"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -215,7 +215,7 @@
       - rule_4.3.1
 
 - name: "NOTSCORED | 4.4.1.1 | AUDIT | Disable IPv6 Router Advertisements"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -227,7 +227,7 @@
       - rule_4.4.1.1
 
 - name: "NOTSCORED | 4.4.1.1 | PATCH | Disable IPv6 Router Advertisements"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -235,7 +235,7 @@
       - rule_4.4.1.1
 
 - name: "NOTSCORED | 4.4.1.2 | AUDIT | Disable IPv6 Redirect Acceptance"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -247,7 +247,7 @@
       - rule_4.4.1.2
 
 - name: "NOTSCORED | 4.4.1.2 | PATCH | Disable IPv6 Redirect Acceptance"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -255,7 +255,7 @@
       - rule_4.4.1.2
 
 - name: "NOTSCORED | 4.4.2 | AUDIT | Disable IPv6"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -267,7 +267,7 @@
       - rule_4.4.2
 
 - name: "NOTSCORED | 4.4.2 | PATCH | Disable IPv6"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -275,7 +275,7 @@
       - rule_4.4.2
 
 - name: "NOTSCORED | 4.5.1 | AUDIT | Install TCP Wrappers"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -287,7 +287,7 @@
       - rule_4.5.1
 
 - name: "NOTSCORED | 4.5.1 | PATCH | Install TCP Wrappers"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -295,7 +295,7 @@
       - rule_4.5.1
 
 - name: "NOTSCORED | 4.5.2 | AUDIT | Create /etc/hosts.allow"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -307,7 +307,7 @@
       - rule_4.5.2
 
 - name: "NOTSCORED | 4.5.2 | PATCH | Create /etc/hosts.allow"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -315,7 +315,7 @@
       - rule_4.5.2
 
 - name: "SCORED | 4.5.3 | AUDIT | Verify Permissions on /etc/hosts.allow"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -327,7 +327,7 @@
       - rule_4.5.3
 
 - name: "SCORED | 4.5.3 | PATCH | Verify Permissions on /etc/hosts.allow"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -335,7 +335,7 @@
       - rule_4.5.3
 
 - name: "NOTSCORED | 4.5.4 | AUDIT | Create /etc/hosts.deny"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -347,7 +347,7 @@
       - rule_4.5.4
 
 - name: "NOTSCORED | 4.5.4 | PATCH | Create /etc/hosts.deny"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -355,7 +355,7 @@
       - rule_4.5.4
 
 - name: "SCORED | 4.5.5 | AUDIT | Verify Permissions on /etc/hosts.deny"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -367,7 +367,7 @@
       - rule_4.5.5
 
 - name: "SCORED | 4.5.5 | PATCH | Verify Permissions on /etc/hosts.deny"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -375,7 +375,7 @@
       - rule_4.5.5
 
 - name: "NOTSCORED | 4.6.1 | AUDIT | Disable DCCP"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -387,7 +387,7 @@
       - rule_4.6.1
 
 - name: "NOTSCORED | 4.6.1 | PATCH | Disable DCCP"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -395,7 +395,7 @@
       - rule_4.6.1
 
 - name: "NOTSCORED | 4.6.2 | AUDIT | Disable SCTP"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -407,7 +407,7 @@
       - rule_4.6.2
 
 - name: "NOTSCORED | 4.6.2 | PATCH | Disable SCTP"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -415,7 +415,7 @@
       - rule_4.6.2
 
 - name: "NOTSCORED | 4.6.3 | AUDIT | Disable RDS"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -427,7 +427,7 @@
       - rule_4.6.3
 
 - name: "NOTSCORED | 4.6.3 | PATCH | Disable RDS"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -435,7 +435,7 @@
       - rule_4.6.3
 
 - name: "NOTSCORED | 4.6.4 | AUDIT | Disable TIPC"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -447,7 +447,7 @@
       - rule_4.6.4
 
 - name: "NOTSCORED | 4.6.4 | PATCH | Disable TIPC"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -455,7 +455,7 @@
       - rule_4.6.4
 
 - name: "SCORED | 4.7 | AUDIT | Enable firewalld"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -467,7 +467,7 @@
       - rule_4.7
 
 - name: "SCORED | 4.7 | PATCH | Enable firewalld"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -1,5 +1,5 @@
 - name: "SCORED | 4.1.1 | AUDIT | Disable IP Forwarding"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv4.ip_forward|grep 0
   register: result
   always_run: yes
   changed_when: no
@@ -11,7 +11,12 @@
       - rule_4.1.1
 
 - name: "SCORED | 4.1.1 | PATCH | Disable IP Forwarding"
-  command: /bin/true
+  sysctl:
+      name: net.ipv4.ip_forward
+      value: 0
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level1
       - level2
@@ -19,7 +24,7 @@
       - rule_4.1.1
 
 - name: "SCORED | 4.1.2 | AUDIT | Disable Send Packet Redirects"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv4.conf.all.send_redirects | grep 0
   register: result
   always_run: yes
   changed_when: no
@@ -31,7 +36,37 @@
       - rule_4.1.2
 
 - name: "SCORED | 4.1.2 | PATCH | Disable Send Packet Redirects"
-  command: /bin/true
+  sysctl:
+      name: net.ipv4.conf.all.send_redirects
+      value: 0
+      state: present
+      reload: yes
+      ignoreerrors: yes
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_4.1.2
+
+- name: "SCORED | 4.1.2 | AUDIT | Disable Send Packet Redirects"
+  shell: /sbin/sysctl net.ipv4.conf.default.send_redirects | grep 0
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_4.1.2
+
+- name: "SCORED | 4.1.2 | PATCH | Disable Send Packet Redirects"
+  sysctl:
+      name: net.ipv4.conf.default.send_redirects
+      value: 0
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level1
       - level2
@@ -39,7 +74,7 @@
       - rule_4.1.2
 
 - name: "SCORED | 4.2.1 | AUDIT | Disable Source Routed Packet Acceptance"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv4.conf.all.accept_source_route | grep 0
   register: result
   always_run: yes
   changed_when: no
@@ -51,7 +86,12 @@
       - rule_4.2.1
 
 - name: "SCORED | 4.2.1 | PATCH | Disable Source Routed Packet Acceptance"
-  command: /bin/true
+  sysctl:
+      name: net.ipv4.conf.all.accept_source_route
+      value: 0
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level1
       - level2
@@ -59,7 +99,7 @@
       - rule_4.2.1
 
 - name: "SCORED | 4.2.2 | AUDIT | Disable ICMP Redirect Acceptance"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv4.conf.all.accept_redirects | grep 0
   register: result
   always_run: yes
   changed_when: no
@@ -71,7 +111,37 @@
       - rule_4.2.2
 
 - name: "SCORED | 4.2.2 | PATCH | Disable ICMP Redirect Acceptance"
-  command: /bin/true
+  sysctl:
+      name: net.ipv4.conf.all.accept_redirects
+      value: 0
+      state: present
+      reload: yes
+      ignoreerrors: yes
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_4.2.2
+
+- name: "SCORED | 4.2.2 | AUDIT | Disable ICMP Redirect Acceptance"
+  shell: /sbin/sysctl net.ipv4.conf.default.accept_redirects | grep 0
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_4.2.2
+
+- name: "SCORED | 4.2.2 | PATCH | Disable ICMP Redirect Acceptance"
+  sysctl:
+      name: net.ipv4.conf.default.accept_redirects
+      value: 0
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level1
       - level2
@@ -79,7 +149,7 @@
       - rule_4.2.2
 
 - name: "SCORED | 4.2.3 | AUDIT | Disable Secure ICMP Redirect Acceptance"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv4.conf.all.secure_redirects | grep 0
   register: result
   always_run: yes
   changed_when: no
@@ -90,14 +160,42 @@
       - rule_4.2.3
 
 - name: "SCORED | 4.2.3 | PATCH | Disable Secure ICMP Redirect Acceptance"
-  command: /bin/true
+  sysctl:
+      name: net.ipv4.conf.all.secure_redirects
+      value: 0
+      state: present
+      reload: yes
+      ignoreerrors: yes
+  tags:
+      - level2
+      - patch
+      - rule_4.2.3
+
+- name: "SCORED | 4.2.3 | AUDIT | Disable Secure ICMP Redirect Acceptance"
+  shell: /sbin/sysctl net.ipv4.conf.default.secure_redirects | grep 0
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level2
+      - audit
+      - rule_4.2.3
+
+- name: "SCORED | 4.2.3 | PATCH | Disable Secure ICMP Redirect Acceptance"
+  sysctl:
+      name: net.ipv4.conf.default.secure_redirects
+      value: 0
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level2
       - patch
       - rule_4.2.3
 
 - name: "SCORED | 4.2.4 | AUDIT | Log Suspicious Packets"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv4.conf.all.log_martians | grep 1
   register: result
   always_run: yes
   changed_when: no
@@ -109,7 +207,37 @@
       - rule_4.2.4
 
 - name: "SCORED | 4.2.4 | PATCH | Log Suspicious Packets"
-  command: /bin/true
+  sysctl:
+      name: net.ipv4.conf.all.log_martians
+      value: 1
+      state: present
+      reload: yes
+      ignoreerrors: yes
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_4.2.4
+
+- name: "SCORED | 4.2.4 | AUDIT | Log Suspicious Packets"
+  shell: /sbin/sysctl net.ipv4.conf.default.log_martians | grep 1
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_4.2.4
+
+- name: "SCORED | 4.2.4 | PATCH | Log Suspicious Packets"
+  sysctl:
+      name: net.ipv4.conf.default.log_martians
+      value: 1
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level1
       - level2
@@ -117,7 +245,7 @@
       - rule_4.2.4
 
 - name: "SCORED | 4.2.5 | AUDIT | Enable Ignore Broadcast Requests"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv4.icmp_echo_ignore_broadcasts | grep 1
   register: result
   always_run: yes
   changed_when: no
@@ -129,7 +257,12 @@
       - rule_4.2.5
 
 - name: "SCORED | 4.2.5 | PATCH | Enable Ignore Broadcast Requests"
-  command: /bin/true
+  sysctl:
+      name: net.ipv4.icmp_echo_ignore_broadcasts
+      value: 1
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level1
       - level2
@@ -137,7 +270,7 @@
       - rule_4.2.5
 
 - name: "SCORED | 4.2.6 | AUDIT | Enable Bad Error Message Protection"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv4.icmp_ignore_bogus_error_responses | grep 1
   register: result
   always_run: yes
   changed_when: no
@@ -149,7 +282,12 @@
       - rule_4.2.6
 
 - name: "SCORED | 4.2.6 | PATCH | Enable Bad Error Message Protection"
-  command: /bin/true
+  sysctl:
+      name: net.ipv4.icmp_ignore_bogus_error_responses
+      value: 1
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level1
       - level2
@@ -157,7 +295,7 @@
       - rule_4.2.6
 
 - name: "SCORED | 4.2.7 | AUDIT | Enable RFC-recommended Source Route Validation"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv4.conf.all.rp_filter | grep 1
   register: result
   always_run: yes
   changed_when: no
@@ -168,14 +306,42 @@
       - rule_4.2.7
 
 - name: "SCORED | 4.2.7 | PATCH | Enable RFC-recommended Source Route Validation"
-  command: /bin/true
+  sysctl:
+      name: net.ipv4.conf.all.rp_filter
+      value: 1
+      state: present
+      reload: yes
+      ignoreerrors: yes
+  tags:
+      - level2
+      - patch
+      - rule_4.2.7
+
+- name: "SCORED | 4.2.7 | AUDIT | Enable RFC-recommended Source Route Validation"
+  shell: /sbin/sysctl net.ipv4.conf.default.rp_filter | grep 1
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level2
+      - audit
+      - rule_4.2.7
+
+- name: "SCORED | 4.2.7 | PATCH | Enable RFC-recommended Source Route Validation"
+  sysctl:
+      name: net.ipv4.conf.default.rp_filter
+      value: 1
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level2
       - patch
       - rule_4.2.7
 
 - name: "SCORED | 4.2.8 | AUDIT | Enable TCP SYN Cookies"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv4.tcp_syncookies | grep 1
   register: result
   always_run: yes
   changed_when: no
@@ -187,7 +353,12 @@
       - rule_4.2.8
 
 - name: "SCORED | 4.2.8 | PATCH | Enable TCP SYN Cookies"
-  command: /bin/true
+  sysctl:
+      name: net.ipv4.tcp_syncookies
+      value: 1
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level1
       - level2
@@ -215,7 +386,7 @@
       - rule_4.3.1
 
 - name: "NOTSCORED | 4.4.1.1 | AUDIT | Disable IPv6 Router Advertisements"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv6.conf.all.accept_ra | grep 0
   register: result
   always_run: yes
   changed_when: no
@@ -227,7 +398,37 @@
       - rule_4.4.1.1
 
 - name: "NOTSCORED | 4.4.1.1 | PATCH | Disable IPv6 Router Advertisements"
-  command: /bin/true
+  sysctl:
+      name: net.ipv6.conf.all.accept_ra
+      value: 0
+      state: present
+      reload: yes
+      ignoreerrors: yes
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_4.4.1.1
+
+- name: "NOTSCORED | 4.4.1.1 | AUDIT | Disable IPv6 Router Advertisements"
+  shell: /sbin/sysctl net.ipv6.conf.default.accept_ra | grep 0
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_4.4.1.1
+
+- name: "NOTSCORED | 4.4.1.1 | PATCH | Disable IPv6 Router Advertisements"
+  sysctl:
+      name: net.ipv6.conf.default.accept_ra
+      value: 0
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level1
       - level2
@@ -235,7 +436,7 @@
       - rule_4.4.1.1
 
 - name: "NOTSCORED | 4.4.1.2 | AUDIT | Disable IPv6 Redirect Acceptance"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv6.conf.all.accept_redirect | grep 0
   register: result
   always_run: yes
   changed_when: no
@@ -247,7 +448,37 @@
       - rule_4.4.1.2
 
 - name: "NOTSCORED | 4.4.1.2 | PATCH | Disable IPv6 Redirect Acceptance"
-  command: /bin/true
+  sysctl:
+      name: net.ipv6.conf.all.accept_redirect
+      value: 0
+      state: present
+      reload: yes
+      ignoreerrors: yes
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_4.4.1.2
+
+- name: "NOTSCORED | 4.4.1.2 | AUDIT | Disable IPv6 Redirect Acceptance"
+  shell: /sbin/sysctl net.ipv6.conf.default.accept_redirect | grep 0
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_4.4.1.2
+
+- name: "NOTSCORED | 4.4.1.2 | PATCH | Disable IPv6 Redirect Acceptance"
+  sysctl:
+      name: net.ipv6.conf.default.accept_redirect
+      value: 0
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level1
       - level2
@@ -255,7 +486,7 @@
       - rule_4.4.1.2
 
 - name: "NOTSCORED | 4.4.2 | AUDIT | Disable IPv6"
-  command: /bin/true
+  shell: /sbin/sysctl net.ipv6.conf.all.disable_ipv6 | grep 1
   register: result
   always_run: yes
   changed_when: no
@@ -267,7 +498,12 @@
       - rule_4.4.2
 
 - name: "NOTSCORED | 4.4.2 | PATCH | Disable IPv6"
-  command: /bin/true
+  sysctl:
+      name: net.ipv6.conf.all.disable_ipv6
+      value: 1
+      state: present
+      reload: yes
+      ignoreerrors: yes
   tags:
       - level1
       - level2
@@ -275,7 +511,7 @@
       - rule_4.4.2
 
 - name: "NOTSCORED | 4.5.1 | AUDIT | Install TCP Wrappers"
-  command: /bin/true
+  command: rpm -q tcp_wrappers
   register: result
   always_run: yes
   changed_when: no
@@ -287,7 +523,9 @@
       - rule_4.5.1
 
 - name: "NOTSCORED | 4.5.1 | PATCH | Install TCP Wrappers"
-  command: /bin/true
+  yum:
+      name=tcp_wrappers
+      state=installed
   tags:
       - level1
       - level2
@@ -295,7 +533,7 @@
       - rule_4.5.1
 
 - name: "NOTSCORED | 4.5.2 | AUDIT | Create /etc/hosts.allow"
-  command: /bin/true
+  command: grep -v '^#' /etc/hosts.allow
   register: result
   always_run: yes
   changed_when: no
@@ -327,7 +565,11 @@
       - rule_4.5.3
 
 - name: "SCORED | 4.5.3 | PATCH | Verify Permissions on /etc/hosts.allow"
-  command: /bin/true
+  file:
+      dest=/etc/hosts.allow
+      owner=root
+      group=root
+      mode=0644
   tags:
       - level1
       - level2
@@ -335,7 +577,7 @@
       - rule_4.5.3
 
 - name: "NOTSCORED | 4.5.4 | AUDIT | Create /etc/hosts.deny"
-  command: /bin/true
+  command: grep -v '^#' /etc/hosts.deny
   register: result
   always_run: yes
   changed_when: no
@@ -367,7 +609,11 @@
       - rule_4.5.5
 
 - name: "SCORED | 4.5.5 | PATCH | Verify Permissions on /etc/hosts.deny"
-  command: /bin/true
+  file:
+      dest=/etc/hosts.deny
+      owner=root
+      group=root
+      mode=0644
   tags:
       - level1
       - level2
@@ -375,7 +621,7 @@
       - rule_4.5.5
 
 - name: "NOTSCORED | 4.6.1 | AUDIT | Disable DCCP"
-  command: /bin/true
+  command: grep -rs "^install\s*dccp\s*/bin/true$" /etc/modprobe.d
   register: result
   always_run: yes
   changed_when: no
@@ -387,7 +633,14 @@
       - rule_4.6.1
 
 - name: "NOTSCORED | 4.6.1 | PATCH | Disable DCCP"
-  command: /bin/true
+  lineinfile:
+      state: present
+      create: yes
+      line: install dccp /bin/true
+      dest: /etc/modprobe.d/disable-dccp.conf
+      owner: root
+      group: root
+      mode: "0644"
   tags:
       - level1
       - level2
@@ -395,7 +648,7 @@
       - rule_4.6.1
 
 - name: "NOTSCORED | 4.6.2 | AUDIT | Disable SCTP"
-  command: /bin/true
+  command: grep -rs "^install\s*sctp\s*/bin/true$" /etc/modprobe.d
   register: result
   always_run: yes
   changed_when: no
@@ -407,7 +660,14 @@
       - rule_4.6.2
 
 - name: "NOTSCORED | 4.6.2 | PATCH | Disable SCTP"
-  command: /bin/true
+  lineinfile:
+      state: present
+      create: yes
+      line: install sctp /bin/true
+      dest: /etc/modprobe.d/disable-sctp.conf
+      owner: root
+      group: root
+      mode: "0644"
   tags:
       - level1
       - level2
@@ -415,7 +675,7 @@
       - rule_4.6.2
 
 - name: "NOTSCORED | 4.6.3 | AUDIT | Disable RDS"
-  command: /bin/true
+  shell: find /etc/modprobe.* -type f -name '*.conf' -exec grep -ls '^install rds /bin/(true|false)' {} \;
   register: result
   always_run: yes
   changed_when: no
@@ -427,7 +687,13 @@
       - rule_4.6.3
 
 - name: "NOTSCORED | 4.6.3 | PATCH | Disable RDS"
-  command: /bin/true
+  copy:
+      backup: no
+      src: disable-rds.conf
+      dest: /etc/modprobe.d/disable-rds.conf
+      owner: root
+      group: root
+      mode: 0644
   tags:
       - level1
       - level2
@@ -435,7 +701,7 @@
       - rule_4.6.3
 
 - name: "NOTSCORED | 4.6.4 | AUDIT | Disable TIPC"
-  command: /bin/true
+  command: grep -rs "^install\s*tipc\s*/bin/true$" /etc/modprobe.d
   register: result
   always_run: yes
   changed_when: no
@@ -447,7 +713,14 @@
       - rule_4.6.4
 
 - name: "NOTSCORED | 4.6.4 | PATCH | Disable TIPC"
-  command: /bin/true
+  lineinfile:
+      state: present
+      create: yes
+      line: install tipc /bin/true
+      dest: /etc/modprobe.d/disable-tipc.conf
+      owner: root
+      group: root
+      mode: "0644"
   tags:
       - level1
       - level2
@@ -455,7 +728,7 @@
       - rule_4.6.4
 
 - name: "SCORED | 4.7 | AUDIT | Enable firewalld"
-  command: /bin/true
+  shell: systemctl is-enabled firewalld|grep enabled
   register: result
   always_run: yes
   changed_when: no
@@ -467,7 +740,7 @@
       - rule_4.7
 
 - name: "SCORED | 4.7 | PATCH | Enable firewalld"
-  command: /bin/true
+  command: systemctl enable firewalld
   tags:
       - level1
       - level2

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -1,5 +1,5 @@
 - name: "SCORED | 5.1.1 | AUDIT | Install the rsyslog package"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -11,7 +11,7 @@
       - rule_5.1.1
 
 - name: "SCORED | 5.1.1 | PATCH | Install the rsyslog package"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -19,7 +19,7 @@
       - rule_5.1.1
 
 - name: "SCORED | 5.1.2 | AUDIT | Activate the rsyslog Service"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -31,7 +31,7 @@
       - rule_5.1.2
 
 - name: "SCORED | 5.1.2 | PATCH | Activate the rsyslog Service"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -39,7 +39,7 @@
       - rule_5.1.2
 
 - name: "NOTSCORED | 5.1.3 | AUDIT | Configure /etc/rsyslog.conf"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -51,7 +51,7 @@
       - rule_5.1.3
 
 - name: "NOTSCORED | 5.1.3 | PATCH | Configure /etc/rsyslog.conf"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -59,7 +59,7 @@
       - rule_5.1.3
 
 - name: "SCORED | 5.1.4 | AUDIT | Create and Set Permissions on rsyslog Log Files"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -71,7 +71,7 @@
       - rule_5.1.4
 
 - name: "SCORED | 5.1.4 | PATCH | Create and Set Permissions on rsyslog Log Files"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -79,7 +79,7 @@
       - rule_5.1.4
 
 - name: "SCORED | 5.1.5 | AUDIT | Configure rsyslog to Send Logs to a Remote Log Host"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -91,7 +91,7 @@
       - rule_5.1.5
 
 - name: "SCORED | 5.1.5 | PATCH | Configure rsyslog to Send Logs to a Remote Log Host"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -99,7 +99,7 @@
       - rule_5.1.5
 
 - name: "NOTSCORED | 5.1.6 | AUDIT | Accept Remote rsyslog Messages Only on Designated Log Hosts"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -111,7 +111,7 @@
       - rule_5.1.6
 
 - name: "NOTSCORED | 5.1.6 | PATCH | Accept Remote rsyslog Messages Only on Designated Log Hosts"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -119,7 +119,7 @@
       - rule_5.1.6
 
 - name: "NOTSCORED | 5.2.1.1 | AUDIT | Configure Audit Log Storage Size"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -130,14 +130,14 @@
       - rule_5.2.1.1
 
 - name: "NOTSCORED | 5.2.1.1 | PATCH | Configure Audit Log Storage Size"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.1.1
 
 - name: "NOTSCORED | 5.2.1.2 | AUDIT | Disable System on Audit Log Full"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -148,14 +148,14 @@
       - rule_5.2.1.2
 
 - name: "NOTSCORED | 5.2.1.2 | PATCH | Disable System on Audit Log Full"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.1.2
 
 - name: "SCORED | 5.2.1.3 | AUDIT | Keep All Auditing Information"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -166,14 +166,14 @@
       - rule_5.2.1.3
 
 - name: "SCORED | 5.2.1.3 | PATCH | Keep All Auditing Information"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.1.3
 
 - name: "SCORED | 5.2.2 | AUDIT | Enable auditd Service"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -184,14 +184,14 @@
       - rule_5.2.2
 
 - name: "SCORED | 5.2.2 | PATCH | Enable auditd Service"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.2
 
 - name: "SCORED | 5.2.3 | AUDIT | Enable Auditing for Processes That Start Prior to auditd"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -202,14 +202,14 @@
       - rule_5.2.3
 
 - name: "SCORED | 5.2.3 | PATCH | Enable Auditing for Processes That Start Prior to auditd"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.3
 
 - name: "SCORED | 5.2.4 | AUDIT | Record Events That Modify Date and Time Information"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -220,14 +220,14 @@
       - rule_5.2.4
 
 - name: "SCORED | 5.2.4 | PATCH | Record Events That Modify Date and Time Information"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.4
 
 - name: "SCORED | 5.2.5 | AUDIT | Record Events That Modify User/Group Information"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -238,14 +238,14 @@
       - rule_5.2.5
 
 - name: "SCORED | 5.2.5 | PATCH | Record Events That Modify User/Group Information"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.5
 
 - name: "SCORED | 5.2.6 | AUDIT | Record Events That Modify the System's Network Environment"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -256,14 +256,14 @@
       - rule_5.2.6
 
 - name: "SCORED | 5.2.6 | PATCH | Record Events That Modify the System's Network Environment"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.6
 
 - name: "SCORED | 5.2.7 | AUDIT | Record Events That Modify the System's Mandatory Access Controls"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -274,14 +274,14 @@
       - rule_5.2.7
 
 - name: "SCORED | 5.2.7 | PATCH | Record Events That Modify the System's Mandatory Access Controls"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.7
 
 - name: "SCORED | 5.2.8 | AUDIT | Collect Login and Logout Events"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -292,14 +292,14 @@
       - rule_5.2.8
 
 - name: "SCORED | 5.2.8 | PATCH | Collect Login and Logout Events"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.8
 
 - name: "SCORED | 5.2.9 | AUDIT | Collect Session Initiation Information"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -310,14 +310,14 @@
       - rule_5.2.9
 
 - name: "SCORED | 5.2.9 | PATCH | Collect Session Initiation Information"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.9
 
 - name: "SCORED | 5.2.10 | AUDIT | Collect Discretionary Access Control Permission Modification Events"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -328,14 +328,14 @@
       - rule_5.2.10
 
 - name: "SCORED | 5.2.10 | PATCH | Collect Discretionary Access Control Permission Modification Events"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.10
 
 - name: "SCORED | 5.2.11 | AUDIT | Collect Unsuccessful Unauthorized Access Attempts to Files"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -346,14 +346,14 @@
       - rule_5.2.11
 
 - name: "SCORED | 5.2.11 | PATCH | Collect Unsuccessful Unauthorized Access Attempts to Files"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.11
 
 - name: "SCORED | 5.2.12 | AUDIT | Collect Use of Privileged Commands"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -364,14 +364,14 @@
       - rule_5.2.12
 
 - name: "SCORED | 5.2.12 | PATCH | Collect Use of Privileged Commands"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.12
 
 - name: "SCORED | 5.2.13 | AUDIT | Collect Successful File System Mounts"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -382,14 +382,14 @@
       - rule_5.2.13
 
 - name: "SCORED | 5.2.13 | PATCH | Collect Successful File System Mounts"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.13
 
 - name: "SCORED | 5.2.14 | AUDIT | Collect File Deletion Events by User"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -400,14 +400,14 @@
       - rule_5.2.14
 
 - name: "SCORED | 5.2.14 | PATCH | Collect File Deletion Events by User"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.14
 
 - name: "SCORED | 5.2.15 | AUDIT | Collect Changes to System Administration Scope (sudoers)"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -418,14 +418,14 @@
       - rule_5.2.15
 
 - name: "SCORED | 5.2.15 | PATCH | Collect Changes to System Administration Scope (sudoers)"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.15
 
 - name: "SCORED | 5.2.16 | AUDIT | Collect System Administrator Actions (sudolog)"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -436,14 +436,14 @@
       - rule_5.2.16
 
 - name: "SCORED | 5.2.16 | PATCH | Collect System Administrator Actions (sudolog)"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.16
 
 - name: "SCORED | 5.2.17 | AUDIT | Collect Kernel Module Loading and Unloading"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -454,14 +454,14 @@
       - rule_5.2.17
 
 - name: "SCORED | 5.2.17 | PATCH | Collect Kernel Module Loading and Unloading"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.17
 
 - name: "SCORED | 5.2.18 | AUDIT | Make the Audit Configuration Immutable"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -472,14 +472,14 @@
       - rule_5.2.18
 
 - name: "SCORED | 5.2.18 | PATCH | Make the Audit Configuration Immutable"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_5.2.18
 
 - name: "NOTSCORED | 5.3 | AUDIT | Configure logrotate"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -491,7 +491,7 @@
       - rule_5.3
 
 - name: "NOTSCORED | 5.3 | PATCH | Configure logrotate"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2

--- a/tasks/section6.yml
+++ b/tasks/section6.yml
@@ -1,5 +1,5 @@
 - name: "SCORED | 6.1.1 | AUDIT | Enable anacron Daemon"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -11,7 +11,7 @@
       - rule_6.1.1
 
 - name: "SCORED | 6.1.1 | PATCH | Enable anacron Daemon"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -19,7 +19,7 @@
       - rule_6.1.1
 
 - name: "SCORED | 6.1.2 | AUDIT | Enable crond Daemon"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -31,7 +31,7 @@
       - rule_6.1.2
 
 - name: "SCORED | 6.1.2 | PATCH | Enable crond Daemon"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -39,7 +39,7 @@
       - rule_6.1.2
 
 - name: "SCORED | 6.1.3 | AUDIT | Set User/Group Owner and Permission on /etc/anacrontab"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -51,7 +51,7 @@
       - rule_6.1.3
 
 - name: "SCORED | 6.1.3 | PATCH | Set User/Group Owner and Permission on /etc/anacrontab"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -59,7 +59,7 @@
       - rule_6.1.3
 
 - name: "SCORED | 6.1.4 | AUDIT | Set User/Group Owner and Permission on /etc/crontab"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -71,7 +71,7 @@
       - rule_6.1.4
 
 - name: "SCORED | 6.1.4 | PATCH | Set User/Group Owner and Permission on /etc/crontab"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -79,7 +79,7 @@
       - rule_6.1.4
 
 - name: "SCORED | 6.1.5 | AUDIT | Set User/Group Owner and Permission on /etc/cron.hourly"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -91,7 +91,7 @@
       - rule_6.1.5
 
 - name: "SCORED | 6.1.5 | PATCH | Set User/Group Owner and Permission on /etc/cron.hourly"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -99,7 +99,7 @@
       - rule_6.1.5
 
 - name: "SCORED | 6.1.6 | AUDIT | Set User/Group Owner and Permission on /etc/cron.daily"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -111,7 +111,7 @@
       - rule_6.1.6
 
 - name: "SCORED | 6.1.6 | PATCH | Set User/Group Owner and Permission on /etc/cron.daily"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -119,7 +119,7 @@
       - rule_6.1.6
 
 - name: "SCORED | 6.1.7 | AUDIT | Set User/Group Owner and Permission on /etc/cron.weekly"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -131,7 +131,7 @@
       - rule_6.1.7
 
 - name: "SCORED | 6.1.7 | PATCH | Set User/Group Owner and Permission on /etc/cron.weekly"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -139,7 +139,7 @@
       - rule_6.1.7
 
 - name: "SCORED | 6.1.8 | AUDIT | Set User/Group Owner and Permission on /etc/cron.monthly"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -151,7 +151,7 @@
       - rule_6.1.8
 
 - name: "SCORED | 6.1.8 | PATCH | Set User/Group Owner and Permission on /etc/cron.monthly"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -159,7 +159,7 @@
       - rule_6.1.8
 
 - name: "SCORED | 6.1.9 | AUDIT | Set User/Group Owner and Permission on /etc/cron.d"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -171,7 +171,7 @@
       - rule_6.1.9
 
 - name: "SCORED | 6.1.9 | PATCH | Set User/Group Owner and Permission on /etc/cron.d"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -179,7 +179,7 @@
       - rule_6.1.9
 
 - name: "SCORED | 6.1.10 | AUDIT | Restrict at Daemon"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -191,7 +191,7 @@
       - rule_6.1.10
 
 - name: "SCORED | 6.1.10 | PATCH | Restrict at Daemon"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -199,7 +199,7 @@
       - rule_6.1.10
 
 - name: "SCORED | 6.1.11 | AUDIT | Restrict at/cron to Authorized Users"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -211,7 +211,7 @@
       - rule_6.1.11
 
 - name: "SCORED | 6.1.11 | PATCH | Restrict at/cron to Authorized Users"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -219,7 +219,7 @@
       - rule_6.1.11
 
 - name: "SCORED | 6.2.1 | AUDIT | Set SSH Protocol to 2"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -231,7 +231,7 @@
       - rule_6.2.1
 
 - name: "SCORED | 6.2.1 | PATCH | Set SSH Protocol to 2"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -239,7 +239,7 @@
       - rule_6.2.1
 
 - name: "SCORED | 6.2.2 | AUDIT | Set LogLevel to INFO"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -251,7 +251,7 @@
       - rule_6.2.2
 
 - name: "SCORED | 6.2.2 | PATCH | Set LogLevel to INFO"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -259,7 +259,7 @@
       - rule_6.2.2
 
 - name: "SCORED | 6.2.3 | AUDIT | Set Permissions on /etc/ssh/sshd_config"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -271,7 +271,7 @@
       - rule_6.2.3
 
 - name: "SCORED | 6.2.3 | PATCH | Set Permissions on /etc/ssh/sshd_config"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -279,7 +279,7 @@
       - rule_6.2.3
 
 - name: "SCORED | 6.2.4 | AUDIT | Disable SSH X11 Forwarding"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -291,7 +291,7 @@
       - rule_6.2.4
 
 - name: "SCORED | 6.2.4 | PATCH | Disable SSH X11 Forwarding"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -299,7 +299,7 @@
       - rule_6.2.4
 
 - name: "SCORED | 6.2.5 | AUDIT | Set SSH MaxAuthTries to 4 or Less"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -311,7 +311,7 @@
       - rule_6.2.5
 
 - name: "SCORED | 6.2.5 | PATCH | Set SSH MaxAuthTries to 4 or Less"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -319,7 +319,7 @@
       - rule_6.2.5
 
 - name: "SCORED | 6.2.6 | AUDIT | Set SSH IgnoreRhosts to Yes"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -331,7 +331,7 @@
       - rule_6.2.6
 
 - name: "SCORED | 6.2.6 | PATCH | Set SSH IgnoreRhosts to Yes"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -339,7 +339,7 @@
       - rule_6.2.6
 
 - name: "SCORED | 6.2.7 | AUDIT | Set SSH HostbasedAuthentication to No"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -351,7 +351,7 @@
       - rule_6.2.7
 
 - name: "SCORED | 6.2.7 | PATCH | Set SSH HostbasedAuthentication to No"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -359,7 +359,7 @@
       - rule_6.2.7
 
 - name: "SCORED | 6.2.8 | AUDIT | Disable SSH Root Login"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -371,7 +371,7 @@
       - rule_6.2.8
 
 - name: "SCORED | 6.2.8 | PATCH | Disable SSH Root Login"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -379,7 +379,7 @@
       - rule_6.2.8
 
 - name: "SCORED | 6.2.9 | AUDIT | Set SSH PermitEmptyPasswords to No"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -391,7 +391,7 @@
       - rule_6.2.9
 
 - name: "SCORED | 6.2.9 | PATCH | Set SSH PermitEmptyPasswords to No"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -399,7 +399,7 @@
       - rule_6.2.9
 
 - name: "SCORED | 6.2.10 | AUDIT | Do Not Allow Users to Set Environment Options"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -411,7 +411,7 @@
       - rule_6.2.10
 
 - name: "SCORED | 6.2.10 | PATCH | Do Not Allow Users to Set Environment Options"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -419,7 +419,7 @@
       - rule_6.2.10
 
 - name: "SCORED | 6.2.11 | AUDIT | Use Only Approved Cipher in Counter Mode"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -431,7 +431,7 @@
       - rule_6.2.11
 
 - name: "SCORED | 6.2.11 | PATCH | Use Only Approved Cipher in Counter Mode"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -439,7 +439,7 @@
       - rule_6.2.11
 
 - name: "SCORED | 6.2.12 | AUDIT | Set Idle Timeout Interval for User Login"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -451,7 +451,7 @@
       - rule_6.2.12
 
 - name: "SCORED | 6.2.12 | PATCH | Set Idle Timeout Interval for User Login"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -459,7 +459,7 @@
       - rule_6.2.12
 
 - name: "SCORED | 6.2.13 | AUDIT | Limit Access via SSH"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -471,7 +471,7 @@
       - rule_6.2.13
 
 - name: "SCORED | 6.2.13 | PATCH | Limit Access via SSH"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -479,7 +479,7 @@
       - rule_6.2.13
 
 - name: "SCORED | 6.2.14 | AUDIT | Set SSH Banner"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -491,7 +491,7 @@
       - rule_6.2.14
 
 - name: "SCORED | 6.2.14 | PATCH | Set SSH Banner"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -499,7 +499,7 @@
       - rule_6.2.14
 
 - name: "SCORED | 6.3.1 | AUDIT | Upgrade Password Hashing Algorithm to SHA-512"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -511,7 +511,7 @@
       - rule_6.3.1
 
 - name: "SCORED | 6.3.1 | PATCH | Upgrade Password Hashing Algorithm to SHA-512"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -519,7 +519,7 @@
       - rule_6.3.1
 
 - name: "SCORED | 6.3.2 | AUDIT | Set Password Creation Requirement Parameters Using pam_pwquality"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -531,7 +531,7 @@
       - rule_6.3.2
 
 - name: "SCORED | 6.3.2 | PATCH | Set Password Creation Requirement Parameters Using pam_pwquality"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -539,7 +539,7 @@
       - rule_6.3.2
 
 - name: "NOTSCORED | 6.3.3 | AUDIT | Set Lockout for Failed Password Attempts"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -551,7 +551,7 @@
       - rule_6.3.3
 
 - name: "NOTSCORED | 6.3.3 | PATCH | Set Lockout for Failed Password Attempts"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -559,7 +559,7 @@
       - rule_6.3.3
 
 - name: "SCORED | 6.3.4 | AUDIT | Limit Password Reuse"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -571,7 +571,7 @@
       - rule_6.3.4
 
 - name: "SCORED | 6.3.4 | PATCH | Limit Password Reuse"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -579,7 +579,7 @@
       - rule_6.3.4
 
 - name: "NOTSCORED | 6.4 | AUDIT | Restrict root Login to System Console"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -591,7 +591,7 @@
       - rule_6.4
 
 - name: "NOTSCORED | 6.4 | PATCH | Restrict root Login to System Console"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -599,7 +599,7 @@
       - rule_6.4
 
 - name: "SCORED | 6.5 | AUDIT | Restrict Access to the su Command"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -611,7 +611,7 @@
       - rule_6.5
 
 - name: "SCORED | 6.5 | PATCH | Restrict Access to the su Command"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2

--- a/tasks/section7.yml
+++ b/tasks/section7.yml
@@ -1,5 +1,5 @@
 - name: "SCORED | 7.1.1 | AUDIT | Set Password Expiration Days"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -11,7 +11,7 @@
       - rule_7.1.1
 
 - name: "SCORED | 7.1.1 | PATCH | Set Password Expiration Days"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -19,7 +19,7 @@
       - rule_7.1.1
 
 - name: "SCORED | 7.1.2 | AUDIT | Set Password Change Minimum Number of Days"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -31,7 +31,7 @@
       - rule_7.1.2
 
 - name: "SCORED | 7.1.2 | PATCH | Set Password Change Minimum Number of Days"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -39,7 +39,7 @@
       - rule_7.1.2
 
 - name: "SCORED | 7.1.3 | AUDIT | Set Password Expiring Warning Days"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -51,7 +51,7 @@
       - rule_7.1.3
 
 - name: "SCORED | 7.1.3 | PATCH | Set Password Expiring Warning Days"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -59,7 +59,7 @@
       - rule_7.1.3
 
 - name: "SCORED | 7.2 | AUDIT | Disable System Accounts"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -71,7 +71,7 @@
       - rule_7.2
 
 - name: "SCORED | 7.2 | PATCH | Disable System Accounts"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -79,7 +79,7 @@
       - rule_7.2
 
 - name: "SCORED | 7.3 | AUDIT | Set Default Group for root Account"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -91,7 +91,7 @@
       - rule_7.3
 
 - name: "SCORED | 7.3 | PATCH | Set Default Group for root Account"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -99,7 +99,7 @@
       - rule_7.3
 
 - name: "SCORED | 7.4 | AUDIT | Set Default umask for Users"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -111,7 +111,7 @@
       - rule_7.4
 
 - name: "SCORED | 7.4 | PATCH | Set Default umask for Users"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -119,7 +119,7 @@
       - rule_7.4
 
 - name: "SCORED | 7.5 | AUDIT | Lock Inactive User Accounts"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -131,7 +131,7 @@
       - rule_7.5
 
 - name: "SCORED | 7.5 | PATCH | Lock Inactive User Accounts"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2

--- a/tasks/section8.yml
+++ b/tasks/section8.yml
@@ -1,5 +1,5 @@
 - name: "SCORED | 8.1 | AUDIT | Set Warning Banner for Standard Login Services"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -11,7 +11,7 @@
       - rule_8.1
 
 - name: "SCORED | 8.1 | PATCH | Set Warning Banner for Standard Login Services"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -19,7 +19,7 @@
       - rule_8.1
 
 - name: "SCORED | 8.2 | AUDIT | Remove OS Information from Login Warning Banners"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -31,7 +31,7 @@
       - rule_8.2
 
 - name: "SCORED | 8.2 | PATCH | Remove OS Information from Login Warning Banners"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -39,7 +39,7 @@
       - rule_8.2
 
 - name: "NOTSCORED | 8.3 | AUDIT | Set GNOME Warning Banner"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -51,7 +51,7 @@
       - rule_8.3
 
 - name: "NOTSCORED | 8.3 | PATCH | Set GNOME Warning Banner"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2

--- a/tasks/section9.yml
+++ b/tasks/section9.yml
@@ -1,5 +1,5 @@
 - name: "NOTSCORED | 9.1.1 | AUDIT | Verify System File Permissions"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -10,14 +10,14 @@
       - rule_9.1.1
 
 - name: "NOTSCORED | 9.1.1 | PATCH | Verify System File Permissions"
-  command: true
+  command: /bin/true
   tags:
       - level2
       - patch
       - rule_9.1.1
 
 - name: "SCORED | 9.1.2 | AUDIT | Verify Permissions on /etc/passwd"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -29,7 +29,7 @@
       - rule_9.1.2
 
 - name: "SCORED | 9.1.2 | PATCH | Verify Permissions on /etc/passwd"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -37,7 +37,7 @@
       - rule_9.1.2
 
 - name: "SCORED | 9.1.3 | AUDIT | Verify Permissions on /etc/shadow"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -49,7 +49,7 @@
       - rule_9.1.3
 
 - name: "SCORED | 9.1.3 | PATCH | Verify Permissions on /etc/shadow"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -57,7 +57,7 @@
       - rule_9.1.3
 
 - name: "SCORED | 9.1.4 | AUDIT | Verify Permissions on /etc/gshadow"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -69,7 +69,7 @@
       - rule_9.1.4
 
 - name: "SCORED | 9.1.4 | PATCH | Verify Permissions on /etc/gshadow"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -77,7 +77,7 @@
       - rule_9.1.4
 
 - name: "SCORED | 9.1.5 | AUDIT | Verify Permissions on /etc/group"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -89,7 +89,7 @@
       - rule_9.1.5
 
 - name: "SCORED | 9.1.5 | PATCH | Verify Permissions on /etc/group"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -97,7 +97,7 @@
       - rule_9.1.5
 
 - name: "SCORED | 9.1.6 | AUDIT | Verify User/Group Ownership on /etc/passwd"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -109,7 +109,7 @@
       - rule_9.1.6
 
 - name: "SCORED | 9.1.6 | PATCH | Verify User/Group Ownership on /etc/passwd"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -117,7 +117,7 @@
       - rule_9.1.6
 
 - name: "SCORED | 9.1.7 | AUDIT | Verify User/Group Ownership on /etc/shadow"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -129,7 +129,7 @@
       - rule_9.1.7
 
 - name: "SCORED | 9.1.7 | PATCH | Verify User/Group Ownership on /etc/shadow"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -137,7 +137,7 @@
       - rule_9.1.7
 
 - name: "SCORED | 9.1.8 | AUDIT | Verify User/Group Ownership on /etc/gshadow"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -149,7 +149,7 @@
       - rule_9.1.8
 
 - name: "SCORED | 9.1.8 | PATCH | Verify User/Group Ownership on /etc/gshadow"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -157,7 +157,7 @@
       - rule_9.1.8
 
 - name: "SCORED | 9.1.9 | AUDIT | Verify User/Group Ownership on /etc/group"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -169,7 +169,7 @@
       - rule_9.1.9
 
 - name: "SCORED | 9.1.9 | PATCH | Verify User/Group Ownership on /etc/group"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -177,7 +177,7 @@
       - rule_9.1.9
 
 - name: "NOTSCORED | 9.1.10 | AUDIT | Find World Writable Files"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -189,7 +189,7 @@
       - rule_9.1.10
 
 - name: "NOTSCORED | 9.1.10 | PATCH | Find World Writable Files"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -197,7 +197,7 @@
       - rule_9.1.10
 
 - name: "SCORED | 9.1.11 | AUDIT | Find Un-owned Files and Directories"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -209,7 +209,7 @@
       - rule_9.1.11
 
 - name: "SCORED | 9.1.11 | PATCH | Find Un-owned Files and Directories"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -217,7 +217,7 @@
       - rule_9.1.11
 
 - name: "SCORED | 9.1.12 | AUDIT | Find Un-grouped Files and Directories"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -229,7 +229,7 @@
       - rule_9.1.12
 
 - name: "SCORED | 9.1.12 | PATCH | Find Un-grouped Files and Directories"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -237,7 +237,7 @@
       - rule_9.1.12
 
 - name: "NOTSCORED | 9.1.13 | AUDIT | Find SUID System Executables"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -249,7 +249,7 @@
       - rule_9.1.13
 
 - name: "NOTSCORED | 9.1.13 | PATCH | Find SUID System Executables"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -257,7 +257,7 @@
       - rule_9.1.13
 
 - name: "NOTSCORED | 9.1.14 | AUDIT | Find SGID System Executables"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -269,7 +269,7 @@
       - rule_9.1.14
 
 - name: "NOTSCORED | 9.1.14 | PATCH | Find SGID System Executables"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -277,7 +277,7 @@
       - rule_9.1.14
 
 - name: "SCORED | 9.2.1 | AUDIT | Ensure Password Fields are Not Empty"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -289,15 +289,15 @@
       - rule_9.2.1
 
 - name: "SCORED | 9.2.1 | PATCH | Ensure Password Fields are Not Empty"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
       - patch
       - rule_9.2.1
 
-- name: "SCORED | 9.2.2 | AUDIT | Verify No Legacy "+" Entries Exist in /etc/passwd File"
-  command: true
+- name: "SCORED | 9.2.2 | AUDIT | Verify No Legacy '+' Entries Exist in /etc/passwd File"
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -308,16 +308,16 @@
       - audit
       - rule_9.2.2
 
-- name: "SCORED | 9.2.2 | PATCH | Verify No Legacy "+" Entries Exist in /etc/passwd File"
-  command: true
+- name: "SCORED | 9.2.2 | PATCH | Verify No Legacy '+' Entries Exist in /etc/passwd File"
+  command: /bin/true
   tags:
       - level1
       - level2
       - patch
       - rule_9.2.2
 
-- name: "SCORED | 9.2.3 | AUDIT | Verify No Legacy "+" Entries Exist in /etc/shadow File"
-  command: true
+- name: "SCORED | 9.2.3 | AUDIT | Verify No Legacy '+' Entries Exist in /etc/shadow File"
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -328,16 +328,16 @@
       - audit
       - rule_9.2.3
 
-- name: "SCORED | 9.2.3 | PATCH | Verify No Legacy "+" Entries Exist in /etc/shadow File"
-  command: true
+- name: "SCORED | 9.2.3 | PATCH | Verify No Legacy '+' Entries Exist in /etc/shadow File"
+  command: /bin/true
   tags:
       - level1
       - level2
       - patch
       - rule_9.2.3
 
-- name: "SCORED | 9.2.4 | AUDIT | Verify No Legacy "+" Entries Exist in /etc/group File"
-  command: true
+- name: "SCORED | 9.2.4 | AUDIT | Verify No Legacy '+' Entries Exist in /etc/group File"
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -348,8 +348,8 @@
       - audit
       - rule_9.2.4
 
-- name: "SCORED | 9.2.4 | PATCH | Verify No Legacy "+" Entries Exist in /etc/group File"
-  command: true
+- name: "SCORED | 9.2.4 | PATCH | Verify No Legacy '+' Entries Exist in /etc/group File"
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -357,7 +357,7 @@
       - rule_9.2.4
 
 - name: "SCORED | 9.2.5 | AUDIT | Verify No UID 0 Accounts Exist Other Than root"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -369,7 +369,7 @@
       - rule_9.2.5
 
 - name: "SCORED | 9.2.5 | PATCH | Verify No UID 0 Accounts Exist Other Than root"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -377,7 +377,7 @@
       - rule_9.2.5
 
 - name: "SCORED | 9.2.6 | AUDIT | Ensure root PATH Integrity"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -389,7 +389,7 @@
       - rule_9.2.6
 
 - name: "SCORED | 9.2.6 | PATCH | Ensure root PATH Integrity"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -397,7 +397,7 @@
       - rule_9.2.6
 
 - name: "SCORED | 9.2.7 | AUDIT | Check Permissions on User Home Directories"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -409,7 +409,7 @@
       - rule_9.2.7
 
 - name: "SCORED | 9.2.7 | PATCH | Check Permissions on User Home Directories"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -417,7 +417,7 @@
       - rule_9.2.7
 
 - name: "SCORED | 9.2.8 | AUDIT | Check User Dot File Permissions"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -429,7 +429,7 @@
       - rule_9.2.8
 
 - name: "SCORED | 9.2.8 | PATCH | Check User Dot File Permissions"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -437,7 +437,7 @@
       - rule_9.2.8
 
 - name: "SCORED | 9.2.9 | AUDIT | Check Permissions on User .netrc Files"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -449,7 +449,7 @@
       - rule_9.2.9
 
 - name: "SCORED | 9.2.9 | PATCH | Check Permissions on User .netrc Files"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -457,7 +457,7 @@
       - rule_9.2.9
 
 - name: "SCORED | 9.2.10 | AUDIT | Check for Presence of User .rhosts Files"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -469,7 +469,7 @@
       - rule_9.2.10
 
 - name: "SCORED | 9.2.10 | PATCH | Check for Presence of User .rhosts Files"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -477,7 +477,7 @@
       - rule_9.2.10
 
 - name: "SCORED | 9.2.11 | AUDIT | Check Groups in /etc/passwd"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -489,7 +489,7 @@
       - rule_9.2.11
 
 - name: "SCORED | 9.2.11 | PATCH | Check Groups in /etc/passwd"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -497,7 +497,7 @@
       - rule_9.2.11
 
 - name: "SCORED | 9.2.12 | AUDIT | Check That Users Are Assigned Valid Home Directories"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -509,7 +509,7 @@
       - rule_9.2.12
 
 - name: "SCORED | 9.2.12 | PATCH | Check That Users Are Assigned Valid Home Directories"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -517,7 +517,7 @@
       - rule_9.2.12
 
 - name: "SCORED | 9.2.13 | AUDIT | Check User Home Directory Ownership"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -529,7 +529,7 @@
       - rule_9.2.13
 
 - name: "SCORED | 9.2.13 | PATCH | Check User Home Directory Ownership"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -537,7 +537,7 @@
       - rule_9.2.13
 
 - name: "SCORED | 9.2.14 | AUDIT | Check for Duplicate UIDs"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -549,7 +549,7 @@
       - rule_9.2.14
 
 - name: "SCORED | 9.2.14 | PATCH | Check for Duplicate UIDs"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -557,7 +557,7 @@
       - rule_9.2.14
 
 - name: "SCORED | 9.2.15 | AUDIT | Check for Duplicate GIDs"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -569,7 +569,7 @@
       - rule_9.2.15
 
 - name: "SCORED | 9.2.15 | PATCH | Check for Duplicate GIDs"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -577,7 +577,7 @@
       - rule_9.2.15
 
 - name: "SCORED | 9.2.16 | AUDIT | Check That Reserved UIDs Are Assigned to System Accounts"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -589,7 +589,7 @@
       - rule_9.2.16
 
 - name: "SCORED | 9.2.16 | PATCH | Check That Reserved UIDs Are Assigned to System Accounts"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -597,7 +597,7 @@
       - rule_9.2.16
 
 - name: "SCORED | 9.2.17 | AUDIT | Check for Duplicate User Names"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -609,7 +609,7 @@
       - rule_9.2.17
 
 - name: "SCORED | 9.2.17 | PATCH | Check for Duplicate User Names"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -617,7 +617,7 @@
       - rule_9.2.17
 
 - name: "SCORED | 9.2.18 | AUDIT | Check for Duplicate Group Names"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -629,7 +629,7 @@
       - rule_9.2.18
 
 - name: "SCORED | 9.2.18 | PATCH | Check for Duplicate Group Names"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -637,7 +637,7 @@
       - rule_9.2.18
 
 - name: "SCORED | 9.2.19 | AUDIT | Check for Presence of User .netrc Files"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -649,7 +649,7 @@
       - rule_9.2.19
 
 - name: "SCORED | 9.2.19 | PATCH | Check for Presence of User .netrc Files"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2
@@ -657,7 +657,7 @@
       - rule_9.2.19
 
 - name: "SCORED | 9.2.20 | AUDIT | Check for Presence of User .forward Files"
-  command: true
+  command: /bin/true
   register: result
   always_run: yes
   changed_when: no
@@ -669,7 +669,7 @@
       - rule_9.2.20
 
 - name: "SCORED | 9.2.20 | PATCH | Check for Presence of User .forward Files"
-  command: true
+  command: /bin/true
   tags:
       - level1
       - level2


### PR DESCRIPTION
I defined the vars and fixed the syntax in order to be able to run the role with all sections succeeding. The  'command: /bin/true' should be replaced by implementations for the various audits and patches. I started implementing the obvious audit and patch actions, but I only have the PDF. We should do CI with oscap xccdf eval. 
