### PR TITLE
Implementations of various audits & patches

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -339,7 +339,7 @@
       - rule_1.1.17
 
 - name: "NOTSCORED | 1.1.18 | AUDIT | Disable Mounting of cramfs Filesystems"
-  command: /bin/true
+  shell: /sbin/lsmod | grep cramfs
   register: result
   always_run: yes
   changed_when: no
@@ -350,14 +350,18 @@
       - rule_1.1.18
 
 - name: "NOTSCORED | 1.1.18 | PATCH | Disable Mounting of cramfs Filesystems"
-  command: /bin/true
+  lineinfile:
+      dest=/etc/modprobe.d/CIS.conf
+      create=yes
+      regexp='^install cramfs'
+      line='install cramfs /bin/true'
   tags:
       - level2
       - patch
       - rule_1.1.18
 
 - name: "NOTSCORED | 1.1.19 | AUDIT | Disable Mounting of freevxfs Filesystems"
-  command: /bin/true
+  shell: /sbin/lsmod | grep freevxfs
   register: result
   always_run: yes
   changed_when: no
@@ -368,14 +372,18 @@
       - rule_1.1.19
 
 - name: "NOTSCORED | 1.1.19 | PATCH | Disable Mounting of freevxfs Filesystems"
-  command: /bin/true
+  lineinfile:
+      dest=/etc/modprobe.d/CIS.conf
+      create=yes
+      regexp='^install freevxfs'
+      line='install freevxfs /bin/true'
   tags:
       - level2
       - patch
       - rule_1.1.19
 
 - name: "NOTSCORED | 1.1.20 | AUDIT | Disable Mounting of jffs2 Filesystems"
-  command: /bin/true
+  shell: /sbin/lsmod | grep jffs2
   register: result
   always_run: yes
   changed_when: no
@@ -386,14 +394,18 @@
       - rule_1.1.20
 
 - name: "NOTSCORED | 1.1.20 | PATCH | Disable Mounting of jffs2 Filesystems"
-  command: /bin/true
+  lineinfile:
+      dest=/etc/modprobe.d/CIS.conf
+      create=yes
+      regexp='^install jffs2'
+      line='install jffs2 /bin/true'
   tags:
       - level2
       - patch
       - rule_1.1.20
 
 - name: "NOTSCORED | 1.1.21 | AUDIT | Disable Mounting of hfs Filesystems"
-  command: /bin/true
+  shell: /sbin/lsmod | grep hfs
   register: result
   always_run: yes
   changed_when: no
@@ -404,14 +416,18 @@
       - rule_1.1.21
 
 - name: "NOTSCORED | 1.1.21 | PATCH | Disable Mounting of hfs Filesystems"
-  command: /bin/true
+  lineinfile:
+      dest=/etc/modprobe.d/CIS.conf
+      create=yes
+      regexp='^install hfs'
+      line='install hfs /bin/true'
   tags:
       - level2
       - patch
       - rule_1.1.21
 
 - name: "NOTSCORED | 1.1.22 | AUDIT | Disable Mounting of hfsplus Filesystems"
-  command: /bin/true
+  shell: /sbin/lsmod | grep hfsplus
   register: result
   always_run: yes
   changed_when: no
@@ -422,14 +438,18 @@
       - rule_1.1.22
 
 - name: "NOTSCORED | 1.1.22 | PATCH | Disable Mounting of hfsplus Filesystems"
-  command: /bin/true
+  lineinfile:
+      dest=/etc/modprobe.d/CIS.conf
+      create=yes
+      regexp='^install hfsplus'
+      line='install hfsplus /bin/true'
   tags:
       - level2
       - patch
       - rule_1.1.22
 
 - name: "NOTSCORED | 1.1.23 | AUDIT | Disable Mounting of squashfs Filesystems"
-  command: /bin/true
+  shell: /sbin/lsmod | grep squashfs
   register: result
   always_run: yes
   changed_when: no
@@ -440,14 +460,18 @@
       - rule_1.1.23
 
 - name: "NOTSCORED | 1.1.23 | PATCH | Disable Mounting of squashfs Filesystems"
-  command: /bin/true
+  lineinfile:
+      dest=/etc/modprobe.d/CIS.conf
+      create=yes
+      regexp='^install squashfs'
+      line='install squashfs /bin/true'
   tags:
       - level2
       - patch
       - rule_1.1.23
 
 - name: "NOTSCORED | 1.1.24 | AUDIT | Disable Mounting of udf Filesystems"
-  command: /bin/true
+  shell: /sbin/lsmod | grep udf
   register: result
   always_run: yes
   changed_when: no
@@ -458,7 +482,11 @@
       - rule_1.1.24
 
 - name: "NOTSCORED | 1.1.24 | PATCH | Disable Mounting of udf Filesystems"
-  command: /bin/true
+  lineinfile:
+      dest=/etc/modprobe.d/CIS.conf
+      create=yes
+      regexp='^install udf'
+      line='install udf /bin/true'
   tags:
       - level2
       - patch

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -45,7 +45,7 @@
       - rule_3.2
 
 - name: "SCORED | 3.3 | AUDIT | Disable Avahi Server"
-  command: /bin/true
+  command: service avahi-daemon status
   register: result
   always_run: yes
   changed_when: no

--- a/tasks/section6.yml
+++ b/tasks/section6.yml
@@ -363,7 +363,11 @@
       - rule_6.2.1
 
 - name: "SCORED | 6.2.1 | PATCH | Set SSH Protocol to 2"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^(#)?Protocol \d'
+      line: 'Protocol 2'
   tags:
       - level1
       - level2
@@ -383,7 +387,11 @@
       - rule_6.2.2
 
 - name: "SCORED | 6.2.2 | PATCH | Set LogLevel to INFO"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^(#)?LogLevel INFO\d'
+      line: 'LogLevel INFO'
   tags:
       - level1
       - level2
@@ -428,7 +436,11 @@
       - rule_6.2.4
 
 - name: "SCORED | 6.2.4 | PATCH | Disable SSH X11 Forwarding"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^(#)?X11Forwarding \d'
+      line: 'X11Forwarding no'
   tags:
       - level1
       - level2
@@ -436,7 +448,7 @@
       - rule_6.2.4
 
 - name: "SCORED | 6.2.5 | AUDIT | Set SSH MaxAuthTries to 4 or Less"
-  command: /bin/true
+  shell: grep "^MaxAuthTries 4" /etc/ssh/sshd_config
   register: result
   always_run: yes
   changed_when: no
@@ -448,7 +460,11 @@
       - rule_6.2.5
 
 - name: "SCORED | 6.2.5 | PATCH | Set SSH MaxAuthTries to 4 or Less"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^(#)?MaxAuthTries \d'
+      line: 'MaxAuthTries 4'
   tags:
       - level1
       - level2
@@ -456,7 +472,7 @@
       - rule_6.2.5
 
 - name: "SCORED | 6.2.6 | AUDIT | Set SSH IgnoreRhosts to Yes"
-  command: /bin/true
+  command: grep "^IgnoreRhosts yes" /etc/ssh/sshd_config
   register: result
   always_run: yes
   changed_when: no
@@ -468,7 +484,11 @@
       - rule_6.2.6
 
 - name: "SCORED | 6.2.6 | PATCH | Set SSH IgnoreRhosts to Yes"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^IgnoreRhosts'
+      line: 'IgnoreRhosts yes'
   tags:
       - level1
       - level2
@@ -476,7 +496,7 @@
       - rule_6.2.6
 
 - name: "SCORED | 6.2.7 | AUDIT | Set SSH HostbasedAuthentication to No"
-  command: /bin/true
+  command: grep "^HostbasedAuthentication no" /etc/ssh/sshd_config
   register: result
   always_run: yes
   changed_when: no
@@ -488,7 +508,11 @@
       - rule_6.2.7
 
 - name: "SCORED | 6.2.7 | PATCH | Set SSH HostbasedAuthentication to No"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^HostbasedAuthentication'
+      line: 'HostbasedAuthentication no'
   tags:
       - level1
       - level2
@@ -496,7 +520,7 @@
       - rule_6.2.7
 
 - name: "SCORED | 6.2.8 | AUDIT | Disable SSH Root Login"
-  command: /bin/true
+  command: grep "^PermitRootLogin no" /etc/ssh/sshd_config
   register: result
   always_run: yes
   changed_when: no
@@ -508,7 +532,11 @@
       - rule_6.2.8
 
 - name: "SCORED | 6.2.8 | PATCH | Disable SSH Root Login"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^PermitRootLogin'
+      line: 'PermitRootLogin no'
   tags:
       - level1
       - level2
@@ -516,7 +544,7 @@
       - rule_6.2.8
 
 - name: "SCORED | 6.2.9 | AUDIT | Set SSH PermitEmptyPasswords to No"
-  command: /bin/true
+  command: grep "^PermitEmptyPasswords no" /etc/ssh/sshd_config
   register: result
   always_run: yes
   changed_when: no
@@ -528,7 +556,11 @@
       - rule_6.2.9
 
 - name: "SCORED | 6.2.9 | PATCH | Set SSH PermitEmptyPasswords to No"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^PermitEmptyPasswords'
+      line: 'PermitEmptyPasswords no'
   tags:
       - level1
       - level2
@@ -536,7 +568,7 @@
       - rule_6.2.9
 
 - name: "SCORED | 6.2.10 | AUDIT | Do Not Allow Users to Set Environment Options"
-  command: /bin/true
+  command: grep "^PermitUserEnvironment no" /etc/ssh/sshd_config
   register: result
   always_run: yes
   changed_when: no
@@ -548,7 +580,11 @@
       - rule_6.2.10
 
 - name: "SCORED | 6.2.10 | PATCH | Do Not Allow Users to Set Environment Options"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^PermitUserEnvironment'
+      line: 'PermitUserEnvironment no'
   tags:
       - level1
       - level2
@@ -556,7 +592,7 @@
       - rule_6.2.10
 
 - name: "SCORED | 6.2.11 | AUDIT | Use Only Approved Cipher in Counter Mode"
-  command: /bin/true
+  command: grep "Ciphers aes128-ctr,aes192-ctr,aes256-ctr" /etc/ssh/sshd_config
   register: result
   always_run: yes
   changed_when: no
@@ -568,7 +604,11 @@
       - rule_6.2.11
 
 - name: "SCORED | 6.2.11 | PATCH | Use Only Approved Cipher in Counter Mode"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^Ciphers'
+      line: 'Ciphers aes128-ctr,aes192-ctr,aes256-ctr'
   tags:
       - level1
       - level2
@@ -576,7 +616,7 @@
       - rule_6.2.11
 
 - name: "SCORED | 6.2.12 | AUDIT | Set Idle Timeout Interval for User Login"
-  command: /bin/true
+  command: grep "^ClientAliveInterval" /etc/ssh/sshd_confige
   register: result
   always_run: yes
   changed_when: no
@@ -588,7 +628,11 @@
       - rule_6.2.12
 
 - name: "SCORED | 6.2.12 | PATCH | Set Idle Timeout Interval for User Login"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^ClientAliveInterval'
+      line: 'ClientAliveInterval 300'
   tags:
       - level1
       - level2
@@ -596,7 +640,7 @@
       - rule_6.2.12
 
 - name: "SCORED | 6.2.13 | AUDIT | Limit Access via SSH"
-  command: /bin/true
+  command: grep "^AllowGroups" /etc/ssh/sshd_config
   register: result
   always_run: yes
   changed_when: no
@@ -616,7 +660,7 @@
       - rule_6.2.13
 
 - name: "SCORED | 6.2.14 | AUDIT | Set SSH Banner"
-  command: /bin/true
+  command: grep "^Banner /etc/issue.net" /etc/ssh/sshd_config
   register: result
   always_run: yes
   changed_when: no
@@ -628,7 +672,11 @@
       - rule_6.2.14
 
 - name: "SCORED | 6.2.14 | PATCH | Set SSH Banner"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^Banner'
+      line: 'Banner /etc/issue.net'
   tags:
       - level1
       - level2
@@ -636,7 +684,7 @@
       - rule_6.2.14
 
 - name: "SCORED | 6.3.1 | AUDIT | Upgrade Password Hashing Algorithm to SHA-512"
-  command: /bin/true
+  shell: authconfig --test | grep hashing | grep sha512
   register: result
   always_run: yes
   changed_when: no
@@ -648,7 +696,7 @@
       - rule_6.3.1
 
 - name: "SCORED | 6.3.1 | PATCH | Upgrade Password Hashing Algorithm to SHA-512"
-  command: /bin/true
+  command: authconfig --passalgo=sha512 --update
   tags:
       - level1
       - level2

--- a/tasks/section6.yml
+++ b/tasks/section6.yml
@@ -1,5 +1,5 @@
 - name: "SCORED | 6.1.1 | AUDIT | Enable anacron Daemon"
-  command: /bin/true
+  shell: rpm -q cronie-anacron
   register: result
   always_run: yes
   changed_when: no
@@ -11,7 +11,9 @@
       - rule_6.1.1
 
 - name: "SCORED | 6.1.1 | PATCH | Enable anacron Daemon"
-  command: /bin/true
+  yum:
+      name=cronie-anacron
+      state=installed
   tags:
       - level1
       - level2
@@ -19,7 +21,7 @@
       - rule_6.1.1
 
 - name: "SCORED | 6.1.2 | AUDIT | Enable crond Daemon"
-  command: /bin/true
+  shell: systemctl is-enabled crond | grep enabled
   register: result
   always_run: yes
   changed_when: no
@@ -31,7 +33,7 @@
       - rule_6.1.2
 
 - name: "SCORED | 6.1.2 | PATCH | Enable crond Daemon"
-  command: /bin/true
+  service: name=crond enabled=yes
   tags:
       - level1
       - level2
@@ -39,7 +41,7 @@
       - rule_6.1.2
 
 - name: "SCORED | 6.1.3 | AUDIT | Set User/Group Owner and Permission on /etc/anacrontab"
-  command: /bin/true
+  shell: stat -L -c "%a %u %g" /etc/anacrontab | egrep ".00 0 0"
   register: result
   always_run: yes
   changed_when: no
@@ -51,7 +53,11 @@
       - rule_6.1.3
 
 - name: "SCORED | 6.1.3 | PATCH | Set User/Group Owner and Permission on /etc/anacrontab"
-  command: /bin/true
+  file:
+      dest=/etc/anacrontab
+      owner=root
+      group=root
+      mode=0600
   tags:
       - level1
       - level2
@@ -59,7 +65,7 @@
       - rule_6.1.3
 
 - name: "SCORED | 6.1.4 | AUDIT | Set User/Group Owner and Permission on /etc/crontab"
-  command: /bin/true
+  shell: stat -L -c "%a %u %g" /etc/crontab | egrep ".00 0 0"
   register: result
   always_run: yes
   changed_when: no
@@ -71,7 +77,11 @@
       - rule_6.1.4
 
 - name: "SCORED | 6.1.4 | PATCH | Set User/Group Owner and Permission on /etc/crontab"
-  command: /bin/true
+  file:
+      dest=/etc/crontab
+      owner=root
+      group=root
+      mode=0600
   tags:
       - level1
       - level2
@@ -79,7 +89,7 @@
       - rule_6.1.4
 
 - name: "SCORED | 6.1.5 | AUDIT | Set User/Group Owner and Permission on /etc/cron.hourly"
-  command: /bin/true
+  shell: stat -L -c "%a %u %g" /etc/cron.hourly | egrep ".00 0 0"
   register: result
   always_run: yes
   changed_when: no
@@ -91,7 +101,11 @@
       - rule_6.1.5
 
 - name: "SCORED | 6.1.5 | PATCH | Set User/Group Owner and Permission on /etc/cron.hourly"
-  command: /bin/true
+  file:
+      dest=/etc/cron.hourly
+      owner=root
+      group=root
+      mode=0600
   tags:
       - level1
       - level2
@@ -99,7 +113,7 @@
       - rule_6.1.5
 
 - name: "SCORED | 6.1.6 | AUDIT | Set User/Group Owner and Permission on /etc/cron.daily"
-  command: /bin/true
+  shell: stat -L -c "%a %u %g" /etc/cron.daily | egrep ".00 0 0"
   register: result
   always_run: yes
   changed_when: no
@@ -111,7 +125,11 @@
       - rule_6.1.6
 
 - name: "SCORED | 6.1.6 | PATCH | Set User/Group Owner and Permission on /etc/cron.daily"
-  command: /bin/true
+  file:
+      dest=/etc/cron.daily
+      owner=root
+      group=root
+      mode=0600
   tags:
       - level1
       - level2
@@ -119,7 +137,7 @@
       - rule_6.1.6
 
 - name: "SCORED | 6.1.7 | AUDIT | Set User/Group Owner and Permission on /etc/cron.weekly"
-  command: /bin/true
+  shell: stat -L -c "%a %u %g" /etc/cron.weekly | egrep ".00 0 0"
   register: result
   always_run: yes
   changed_when: no
@@ -131,7 +149,11 @@
       - rule_6.1.7
 
 - name: "SCORED | 6.1.7 | PATCH | Set User/Group Owner and Permission on /etc/cron.weekly"
-  command: /bin/true
+  file:
+      dest=/etc/cron.weekly
+      owner=root
+      group=root
+      mode=0600
   tags:
       - level1
       - level2
@@ -139,7 +161,7 @@
       - rule_6.1.7
 
 - name: "SCORED | 6.1.8 | AUDIT | Set User/Group Owner and Permission on /etc/cron.monthly"
-  command: /bin/true
+  shell: stat -L -c "%a %u %g" /etc/cron.monthly | egrep ".00 0 0"
   register: result
   always_run: yes
   changed_when: no
@@ -151,7 +173,11 @@
       - rule_6.1.8
 
 - name: "SCORED | 6.1.8 | PATCH | Set User/Group Owner and Permission on /etc/cron.monthly"
-  command: /bin/true
+  file:
+      dest=/etc/cron.monthly
+      owner=root
+      group=root
+      mode=0600
   tags:
       - level1
       - level2
@@ -159,7 +185,7 @@
       - rule_6.1.8
 
 - name: "SCORED | 6.1.9 | AUDIT | Set User/Group Owner and Permission on /etc/cron.d"
-  command: /bin/true
+  shell: stat -L -c "%a %u %g" /etc/cron.d | egrep ".00 0 0"
   register: result
   always_run: yes
   changed_when: no
@@ -171,7 +197,12 @@
       - rule_6.1.9
 
 - name: "SCORED | 6.1.9 | PATCH | Set User/Group Owner and Permission on /etc/cron.d"
-  command: /bin/true
+  file:
+      dest=/etc/cron.d
+      state=directory
+      owner=root
+      group=root
+      mode=0600
   tags:
       - level1
       - level2
@@ -179,7 +210,19 @@
       - rule_6.1.9
 
 - name: "SCORED | 6.1.10 | AUDIT | Restrict at Daemon"
-  command: /bin/true
+  shell: stat -L /etc/at.deny > /dev/null
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_6.1.10
+
+- name: "SCORED | 6.1.10 | AUDIT | Restrict at Daemon"
+  shell: stat -L -c "%a %u %g" /etc/at.allow | egrep ".00 0 0"
   register: result
   always_run: yes
   changed_when: no
@@ -191,7 +234,22 @@
       - rule_6.1.10
 
 - name: "SCORED | 6.1.10 | PATCH | Restrict at Daemon"
-  command: /bin/true
+  file:
+      dest=/etc/at.deny
+      state=absent
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_6.1.10
+
+- name: "SCORED | 6.1.10 | PATCH | Restrict at Daemon"
+  file:
+      dest=/etc/at.allow
+      state=touch
+      owner=root
+      group=root
+      mode=0600
   tags:
       - level1
       - level2
@@ -199,7 +257,43 @@
       - rule_6.1.10
 
 - name: "SCORED | 6.1.11 | AUDIT | Restrict at/cron to Authorized Users"
-  command: /bin/true
+  shell: ls -l /etc/cron.deny | grep '^$'
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_6.1.11
+
+- name: "SCORED | 6.1.11 | AUDIT | Restrict at/cron to Authorized Users"
+  shell: ls -l /etc/at.deny | grep '^$'
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_6.1.11
+
+- name: "SCORED | 6.1.11 | AUDIT | Restrict at/cron to Authorized Users"
+  shell: ls -l /etc/cron.allow
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_6.1.11
+
+- name: "SCORED | 6.1.11 | AUDIT | Restrict at/cron to Authorized Users"
+  shell: ls -l /etc/at.allow
   register: result
   always_run: yes
   changed_when: no
@@ -211,7 +305,45 @@
       - rule_6.1.11
 
 - name: "SCORED | 6.1.11 | PATCH | Restrict at/cron to Authorized Users"
-  command: /bin/true
+  file:
+      dest=/etc/cron.deny
+      state=absent
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_6.1.11
+
+- name: "SCORED | 6.1.11 | PATCH | Restrict at/cron to Authorized Users"
+  file:
+      dest=/etc/at.deny
+      state=absent
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_6.1.11
+
+- name: "SCORED | 6.1.11 | PATCH | Restrict at/cron to Authorized Users"
+  file:
+      dest=/etc/cron.allow
+      state=touch
+      owner=root
+      group=root
+      mode=0600
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_6.1.11
+
+- name: "SCORED | 6.1.11 | PATCH | Restrict at/cron to Authorized Users"
+  file:
+      dest=/etc/at.allow
+      state=touch
+      owner=root
+      group=root
+      mode=0600
   tags:
       - level1
       - level2
@@ -219,7 +351,7 @@
       - rule_6.1.11
 
 - name: "SCORED | 6.2.1 | AUDIT | Set SSH Protocol to 2"
-  command: /bin/true
+  command: grep "^Protocol 2" /etc/ssh/sshd_config
   register: result
   always_run: yes
   changed_when: no
@@ -239,7 +371,7 @@
       - rule_6.2.1
 
 - name: "SCORED | 6.2.2 | AUDIT | Set LogLevel to INFO"
-  command: /bin/true
+  command: grep "^LogLevel INFO" /etc/ssh/sshd_config
   register: result
   always_run: yes
   changed_when: no
@@ -259,7 +391,7 @@
       - rule_6.2.2
 
 - name: "SCORED | 6.2.3 | AUDIT | Set Permissions on /etc/ssh/sshd_config"
-  command: /bin/true
+  shell: stat -L -c "%a %u %g" /etc/ssh/sshd_config | egrep ".00 0 0"
   register: result
   always_run: yes
   changed_when: no
@@ -271,7 +403,12 @@
       - rule_6.2.3
 
 - name: "SCORED | 6.2.3 | PATCH | Set Permissions on /etc/ssh/sshd_config"
-  command: /bin/true
+  file:
+      dest=/etc/ssh/sshd_config
+      state=file
+      owner=root
+      group=root
+      mode=0600
   tags:
       - level1
       - level2
@@ -279,7 +416,7 @@
       - rule_6.2.3
 
 - name: "SCORED | 6.2.4 | AUDIT | Disable SSH X11 Forwarding"
-  command: /bin/true
+  command: grep "^X11Forwarding no" /etc/ssh/sshd_config
   register: result
   always_run: yes
   changed_when: no

--- a/tasks/section7.yml
+++ b/tasks/section7.yml
@@ -79,7 +79,7 @@
       - rule_7.2
 
 - name: "SCORED | 7.3 | AUDIT | Set Default Group for root Account"
-  command: /bin/true
+  shell: grep "^root:" /etc/passwd | cut -f4 -d:|grep 0
   register: result
   always_run: yes
   changed_when: no
@@ -91,7 +91,7 @@
       - rule_7.3
 
 - name: "SCORED | 7.3 | PATCH | Set Default Group for root Account"
-  command: /bin/true
+  command: usermod -g 0 root
   tags:
       - level1
       - level2
@@ -99,7 +99,19 @@
       - rule_7.3
 
 - name: "SCORED | 7.4 | AUDIT | Set Default umask for Users"
-  command: /bin/true
+  command: grep "^umask 077" /etc/bashrc
+  register: result
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_7.4
+
+- name: "SCORED | 7.4 | AUDIT | Set Default umask for Users"
+  command: grep "^umask 077" /etc/profile.d/*
   register: result
   always_run: yes
   changed_when: no
@@ -111,7 +123,29 @@
       - rule_7.4
 
 - name: "SCORED | 7.4 | PATCH | Set Default umask for Users"
-  command: /bin/true
+  lineinfile:
+      state: present
+      create: yes
+      line: 'umask 077'
+      dest: /etc/bashrc
+      owner: root
+      group: root
+      mode: "0644"
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_7.4
+
+- name: "SCORED | 7.4 | PATCH | Set Default umask for Users"
+  lineinfile:
+      state: present
+      create: yes
+      line: 'umask 077'
+      dest: /etc/profile.d/cis.sh
+      owner: root
+      group: root
+      mode: "0644"
   tags:
       - level1
       - level2


### PR DESCRIPTION
Here are some more implementations based on the PDF of CIS_CentOS_Linux_7_Benchmark_v1.0.0.pdf. The patches implement the remidiation, and the audits are the stated commands, or return 0 for a secure result. The audits ideally throw red errors when the finding is negative and they should print green when everything is fine. At the moment this is not consistent over the audit actions in all sections.
