### PR TITLE
More work done on audits in section 1, 3, 4 and 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Example Playbook
   roles:
     - RHEL7-CIS
 
-
 Tags
 ----
 Many tags are available for precise control of what is and is not changed.

--- a/files/grub
+++ b/files/grub
@@ -1,7 +1,0 @@
-GRUB_TIMEOUT=5
-GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
-GRUB_DEFAULT=saved
-GRUB_DISABLE_SUBMENU=true
-GRUB_TERMINAL_OUTPUT="console"
-GRUB_CMDLINE_LINUX="crashkernel=auto rd.lvm.lv=systemvg/rootlv rd.lvm.lv=systemvg/swaplv rhgb quiet"
-GRUB_DISABLE_RECOVERY="true"

--- a/files/grub
+++ b/files/grub
@@ -1,0 +1,7 @@
+GRUB_TIMEOUT=5
+GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
+GRUB_DEFAULT=saved
+GRUB_DISABLE_SUBMENU=true
+GRUB_TERMINAL_OUTPUT="console"
+GRUB_CMDLINE_LINUX="crashkernel=auto rd.lvm.lv=systemvg/rootlv rd.lvm.lv=systemvg/swaplv rhgb quiet"
+GRUB_DISABLE_RECOVERY="true"

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -618,8 +618,8 @@
       - rule_1.1.21
 
 - name: "SCORED | 1.1.22 | AUDIT | Disable Automounting"
-  command: /bin/true
-  register: result
+  command: systemctl is-enabled autofs
+  register: disable_automounting_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -631,6 +631,7 @@
 
 - name: "SCORED | 1.1.22 | PATCH | Disable Automounting"
   command: /bin/true
+  when: disable_automounting_audit.rc
   tags:
       - level1
       - level2
@@ -823,7 +824,7 @@
       - rule_1.3.2
 
 - name: "SCORED | 1.4.1 | AUDIT | Ensure permissions on bootloader config are configured"
-  command: /bin/true
+  shell: stat -L -c "%a %u %g" /boot/grub2/grub.cfg | egrep "600 0 0"
   register: result
   always_run: yes
   changed_when: no
@@ -835,7 +836,12 @@
       - rule_1.4.1
 
 - name: "SCORED | 1.4.1 | PATCH | Ensure permissions on bootloader config are configured"
-  command: /bin/true
+  file:
+      dest: /boot/grub2/grub.cfg
+      state: file
+      owner: root
+      group: root
+      mode: 0600
   tags:
       - level1
       - scored
@@ -843,7 +849,7 @@
       - rule_1.4.1
 
 - name: "SCORED | 1.4.2 | AUDIT | Ensure bootloader password is set"
-  command: /bin/true
+  command: grep "^password" /boot/grub2/grub.cfg
   register: result
   always_run: yes
   changed_when: no
@@ -1204,7 +1210,7 @@ print $NF }'"
       - rule_1.6.2
 
 - name: "SCORED | 1.7.1.1 | AUDIT | Ensure message of the day is configured properly"
-  command: egrep '(\\v|\\r|\\m|\\s)' /etc/motd
+  command: egrep -v '(\\v|\\r|\\m|\\s)' /etc/motd
   register: configured_etc_motd_audit
   always_run: yes
   changed_when: no
@@ -1217,6 +1223,7 @@ print $NF }'"
 
 - name: "SCORED | 1.7.1.1 | PATCH | Ensure message of the day is configured properly"
   command: /bin/true
+  when: configured_etc_motd_audit.rc
   tags:
       - level1
       - level2
@@ -1224,7 +1231,7 @@ print $NF }'"
       - rule_1.7.1.1
 
 - name: "NOTSCORED | 1.7.1.2 | AUDIT | Ensure local login warning banner is configured properly"
-  command: egrep '(\\v|\\r|\\m|\\s)' /etc/issue
+  command: egrep -e '(\\v|\\r|\\m|\\s)' /etc/issue
   register: configured_etc_issue_audit
   always_run: yes
   changed_when: no
@@ -1237,6 +1244,7 @@ print $NF }'"
 
 - name: "NOTSCORED | 1.7.1.2 | PATCH | Ensure local login warning banner is configured properly"
   command: /bin/true
+  when: configured_etc_issue_audit.rc
   tags:
       - level1
       - level2
@@ -1244,7 +1252,7 @@ print $NF }'"
       - rule_1.7.1.2
 
 - name: "NOTSCORED | 1.7.1.3 | AUDIT | Ensure remote login warning banner is configured properly"
-  command: egrep '(\\v|\\r|\\m|\\s)' /etc/issue.net
+  command: egrep -v '(\\v|\\r|\\m|\\s)' /etc/issue.net
   register: configured_etc_issue_net_audit
   always_run: yes
   changed_when: no
@@ -1257,6 +1265,7 @@ print $NF }'"
 
 - name: "NOTSCORED | 1.7.1.3 | PATCH | Ensure remote login warning banner is configured properly"
   command: /bin/true
+  when: configured_etc_issue_net_audit.rc
   tags:
       - level1
       - level2
@@ -1339,8 +1348,21 @@ print $NF }'"
       - rule_1.7.1.6
 
 - name: "SCORED | 1.7.2 | AUDIT | Ensure GDM login banner is configured"
-  command: /bin/true
-  register: result
+  command: rpm -q gdm
+  register: gdm_installed_audit
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_1.7.2
+
+- name: "SCORED | 1.7.2 | AUDIT | Ensure GDM login banner is configured"
+  command: grep 'banner-message-enable=true' /etc/dconf/db/gdm.d/01-banner-message
+  register: gdm_login_banner_configured_audit
+  when: gdm_installed_audit.rc == '0'
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -1352,6 +1374,7 @@ print $NF }'"
 
 - name: "SCORED | 1.7.2 | PATCH | Ensure GDM login banner is configured"
   command: /bin/true
+  when: gdm_installed_audit.rc == '0' and gdm_login_banner_configured_audit
   tags:
       - level1
       - level2

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -335,6 +335,7 @@
 
 - name: "SCORED | 1.1.3 | PATCH | Ensure nodev option set on /tmp partition"
   command: /bin/true
+  when: tmp_nodev_audit.rc
   tags:
       - level1
       - scored
@@ -355,6 +356,7 @@
 
 - name: "SCORED | 1.1.4 | PATCH | Ensure nosuid option set on /tmp partition"
   command: /bin/true
+  when: mount_nosuid_tmp_audit.rc
   tags:
       - level1
       - level2
@@ -362,7 +364,7 @@
       - rule_1.1.4
 
 - name: "SCORED | 1.1.5 | AUDIT | Ensure noexec option set on /tmp partition"
-  shell: mount | grep /tmp | grep noexec
+  shell: mount | grep ' /tmp' | grep noexec
   register: mount_noexec_tmp_audit
   always_run: yes
   changed_when: no
@@ -375,6 +377,7 @@
 
 - name: "SCORED | 1.1.5 | PATCH | Ensure noexec option set on /tmp partition"
   command: /bin/true
+  when: mount_noexec_tmp_audit.rc
   tags:
       - level1
       - level2
@@ -401,6 +404,7 @@
 
 - name: "SCORED | 1.1.8 | PATCH | Ensure nodev option set on /var/tmp partition"
   command: /bin/true
+  when: mount_nodev_var_tmp_audit.rc
   tags:
       - level1
       - level2
@@ -421,6 +425,7 @@
 
 - name: "SCORED | 1.1.9 | PATCH | Ensure nosuid option set on /var/tmp partition"
   command: /bin/true
+  when: mount_nosuid_var_tmp_audit.rc
   tags:
       - level1
       - level2
@@ -441,6 +446,7 @@
 
 - name: "SCORED | 1.1.10 | PATCH | Ensure noexec option set on /var/tmp partition"
   command: /bin/true
+  when: mount_noexec_var_tmp_audit.rc
   tags:
       - level1
       - level2
@@ -470,6 +476,7 @@
 
 - name: "SCORED | 1.1.14 | PATCH | Ensure nodev option set on /home partition"
   command: /bin/true
+  when: mount_nodev_home_audit.rc
   tags:
       - level1
       - level2
@@ -490,6 +497,7 @@
 
 - name: "SCORED | 1.1.15 | PATCH | Ensure nodev option set on /dev/shm partition"
   command: /bin/true
+  when: mount_nodev_dev_shm_audit.rc
   tags:
       - level1
       - level2
@@ -510,6 +518,7 @@
 
 - name: "SCORED | 1.1.16 | PATCH | Ensure nosuid option set on /dev/shm partition"
   command: /bin/true
+  when: mount_nosuid_dev_shm_audit.rc
   tags:
       - level1
       - level2
@@ -610,7 +619,7 @@
 
 - name: "SCORED | 1.1.21 | PATCH | Ensure sticky bit is set on all world-writable directories"
   shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d -perm -0002 2>/dev/null | xargs chmod a+t
-  when: sticky_bit_on_worldwritable_dirs_audit.rc
+  when: sticky_bit_on_worldwritable_dirs_audit.rc == '0'
   tags:
       - level1
       - level2
@@ -618,7 +627,20 @@
       - rule_1.1.21
 
 - name: "SCORED | 1.1.22 | AUDIT | Disable Automounting"
+  command: rpm -q autofs
+  register: autofs_installed_audit
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_1.1.22
+
+- name: "SCORED | 1.1.22 | AUDIT | Disable Automounting"
   command: systemctl is-enabled autofs
+  when: autofs_installed_audit.rc == '0'
   register: disable_automounting_audit
   always_run: yes
   changed_when: no
@@ -631,7 +653,7 @@
 
 - name: "SCORED | 1.1.22 | PATCH | Disable Automounting"
   command: /bin/true
-  when: disable_automounting_audit.rc
+  when: autofs_installed_audit.rc == '0' and disable_automounting_audit.rc
   tags:
       - level1
       - level2
@@ -681,7 +703,7 @@
       - rule_1.2.2
 
 - name: "NOTSCORED | 1.2.3 | AUDIT | Ensure GPG keys are configured"
-  command: rpm -q gpg-pubkey --qf '%{name}-%{version}-%{release} --> %{summary}\n'
+  shell: grep ^gpgcheck /etc/yum.repos.d/* | grep -v 0$
   register: yum_gpg_keys_configured_audit
   always_run: yes
   changed_when: no
@@ -836,7 +858,12 @@
       - rule_1.4.1
 
 - name: "SCORED | 1.4.1 | PATCH | Ensure permissions on bootloader config are configured"
-  command: /bin/true
+  file:
+    path: /boot/grub2/grub.cfg
+    state: file
+    owner: root
+    group: root
+    mode:  0600
   tags:
       - level1
       - scored
@@ -864,8 +891,8 @@
       - rule_1.4.2
 
 - name: "NOTSCORED | 1.4.3 | AUDIT | Ensure authentication required for single user mode"
-  command: /bin/true
-  register: result
+  command: grep /sbin/sulogin /usr/lib/systemd/system/rescue.service
+  register: authentications_for_rescue_service_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -877,6 +904,28 @@
 
 - name: "NOTSCORED | 1.4.3 | PATCH | Ensure authentication required for single user mode"
   command: /bin/true
+  when: authentications_for_rescue_service_audit.rc
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_1.4.3
+
+- name: "NOTSCORED | 1.4.3 | AUDIT | Ensure authentication required for single user mode"
+  command: grep /sbin/sulogin /usr/lib/systemd/system/emergency.service
+  register: authentications_for_emergency_service_audit
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_1.4.3
+
+- name: "NOTSCORED | 1.4.3 | PATCH | Ensure authentication required for single user mode"
+  command: /bin/true
+  when: authentications_for_emergency_service_audit.rc
   tags:
       - level1
       - level2
@@ -1139,6 +1188,7 @@
   yum:
       name: setroubleshoot
       state: absent
+  when: setroubleshoot_removed_audit.rc == '0'
   tags:
       - level2
       - scored
@@ -1162,6 +1212,7 @@
   yum:
       name: mcstrans
       state: absent
+  when: mcstrans_removed_audit.rc == '0'
   tags:
       - level2
       - scored
@@ -1198,6 +1249,7 @@ print $NF }'"
   yum:
       name: libselinux
       state: present
+  when: selinux_installed_audit.rc
   tags:
       - level2
       - scored
@@ -1226,7 +1278,7 @@ print $NF }'"
       - rule_1.7.1.1
 
 - name: "NOTSCORED | 1.7.1.2 | AUDIT | Ensure local login warning banner is configured properly"
-  command: egrep -e '(\\v|\\r|\\m|\\s)' /etc/issue
+  command: egrep -v '(\\v|\\r|\\m|\\s)' /etc/issue
   register: configured_etc_issue_audit
   always_run: yes
   changed_when: no
@@ -1389,7 +1441,9 @@ print $NF }'"
       - rule_1.8
 
 - name: "NOTSCORED | 1.8 | PATCH | Ensure updates, patches, and additional security software are installed"
-  command: /bin/true
+  yum:
+    name: "*"
+    state: latest
   tags:
       - level1
       - level2

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -858,12 +858,7 @@
       - rule_1.4.1
 
 - name: "SCORED | 1.4.1 | PATCH | Ensure permissions on bootloader config are configured"
-  file:
-    path: /boot/grub2/grub.cfg
-    state: file
-    owner: root
-    group: root
-    mode:  0600
+  command: /bin/true
   tags:
       - level1
       - scored

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -1437,8 +1437,8 @@ print $NF }'"
 
 - name: "NOTSCORED | 1.8 | PATCH | Ensure updates, patches, and additional security software are installed"
   yum:
-    name: "*"
-    state: latest
+      name: "*"
+     state: latest
   tags:
       - level1
       - level2

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -12,7 +12,7 @@
       - cramfs
 
 - name: "SCORED | 1.1.1.1 | AUDIT | Ensure mounting of cramfs filesystems is disabled"
-  shell: lsmod | grep cramfs
+  shell: lsmod | grep -vq cramfs
   register: cramfs_loaded_audit
   always_run: yes
   changed_when: no
@@ -52,7 +52,7 @@
       - freevxfs
 
 - name: "SCORED | 1.1.1.2 | AUDIT | Ensure mounting of freevxfs filesystems is disabled"
-  shell: lsmod | grep freevxfs
+  shell: lsmod | grep -vq freevxfs
   register: freevxfs_loaded_audit
   always_run: yes
   changed_when: no
@@ -92,7 +92,7 @@
       - jffs2
 
 - name: "SCORED | 1.1.1.3 | AUDIT | Ensure mounting of jffs2 filesystems is disabled"
-  shell: lsmod | grep jffs2
+  shell: lsmod | grep -vq jffs2
   register: jffs2_loaded_audit
   always_run: yes
   changed_when: no
@@ -132,7 +132,7 @@
       - hfs
 
 - name: "SCORED | 1.1.1.4 | AUDIT | Ensure mounting of hfs filesystems is disabled"
-  shell: lsmod | grep hfs
+  shell: lsmod | grep -vq hfs
   register: hfs_loaded_audit
   always_run: yes
   changed_when: no
@@ -172,7 +172,7 @@
       - hfsplus
 
 - name: "SCORED | 1.1.1.5 | AUDIT | Ensure mounting of hfsplus filesystems is disabled"
-  shell: lsmod | grep hfsplus
+  shell: lsmod | grep -vq hfsplus
   register: hfsplus_loaded_audit
   always_run: yes
   changed_when: no
@@ -212,7 +212,7 @@
       - squashfs
 
 - name: "SCORED | 1.1.1.6 | AUDIT | Ensure mounting of squashfs filesystems is disabled"
-  shell: lsmod | grep squashfs
+  shell: lsmod | grep -vq squashfs
   register: squashfs_loaded_audit
   always_run: yes
   changed_when: no
@@ -252,7 +252,7 @@
       - udf
 
 - name: "SCORED | 1.1.1.7 | AUDIT | Ensure mounting of udf filesystems is disabled"
-  shell: lsmod | grep udf
+  shell: lsmod | grep -vq udf
   register: udf_loaded_audit
   always_run: yes
   changed_when: no
@@ -292,7 +292,7 @@
       - vfat
 
 - name: "SCORED | 1.1.1.8 | AUDIT | Ensure mounting of FAT filesystems is disabled"
-  shell: lsmod | grep vfat
+  shell: lsmod | grep -vq vfat
   register: vfat_loaded_audit
   always_run: yes
   changed_when: no

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -836,12 +836,7 @@
       - rule_1.4.1
 
 - name: "SCORED | 1.4.1 | PATCH | Ensure permissions on bootloader config are configured"
-  file:
-      dest: /boot/grub2/grub.cfg
-      state: file
-      owner: root
-      group: root
-      mode: 0600
+  command: /bin/true
   tags:
       - level1
       - scored

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -1438,7 +1438,7 @@ print $NF }'"
 - name: "NOTSCORED | 1.8 | PATCH | Ensure updates, patches, and additional security software are installed"
   yum:
       name: "*"
-     state: latest
+      state: latest
   tags:
       - level1
       - level2

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -610,8 +610,34 @@
       - rule_3.6.1
 
 - name: "SCORED | 3.6.2 | AUDIT | Ensure default deny firewall policy"
-  command: /bin/true
-  register: result
+  shell: iptables -L | grep 'Chain INPUT' | grep DROP
+  register: default_deny_input_policy_audit
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  when: rhel7cis_firewall == "iptables"
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_3.6.2
+
+- name: "SCORED | 3.6.2 | AUDIT | Ensure default deny firewall policy"
+  shell: iptables -L | grep 'Chain FORWARD' | grep DROP
+  register: default_deny_forward_policy_audit
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  when: rhel7cis_firewall == "iptables"
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_3.6.2
+
+- name: "SCORED | 3.6.2 | AUDIT | Ensure default deny firewall policy"
+  shell: iptables -L | grep 'Chain OUTPUT' | grep DROP
+  register: default_deny_output_policy_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -632,8 +658,21 @@
       - rule_3.6.2
 
 - name: "SCORED | 3.6.3 | AUDIT | Ensure loopback traffic is configured"
-  command: /bin/true
-  register: result
+  shell: iptables -L INPUT -v -n| grep lo | grep ACCEPT
+  register: ensure_loopback_interface_accepts_traffic_audit
+  always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  when: rhel7cis_firewall == "iptables"
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_3.6.3
+
+- name: "SCORED | 3.6.3 | AUDIT | Ensure loopback traffic is configured"
+  shell: iptables -L INPUT -v -n | grep 127.0.0.0/8|grep DROP
+  register: ensure_other_interfaces_drop_loopback_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -646,7 +685,7 @@
 
 - name: "SCORED | 3.6.3 | PATCH | Ensure loopback traffic is configured"
   command: /bin/true
-  when: rhel7cis_firewall == "iptables"
+  when: rhel7cis_firewall == "iptables" and ( ensure_loopback_interface_accepts_traffic_audit.rc or ensure_other_interfaces_drop_loopback_audit.rc )
   tags:
       - level1
       - level2

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -459,7 +459,7 @@
       - patch
       - rule_4.1.18
 
-- name: "SCORED | 4.2.1.1 | AUDIT | command: /bin/true"
+- name: "SCORED | 4.2.1.1 | AUDIT | Ensure rsyslog Service is enabled"
   command: systemctl is-enabled rsyslog
   register: rsyslog_service_enabled_audit
   always_run: yes

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -10,6 +10,16 @@
       - rule_4.1.1.1
 
 - name: "NOTSCORED | 4.1.1.1 | PATCH | Ensure audit log storage size is configured"
+  yum:
+      name: audit
+      state: present
+  when: audit_log_storage_size_audit.rc
+  tags:
+      - level2
+      - patch
+      - rule_4.1.1.1
+
+- name: "NOTSCORED | 4.1.1.1 | PATCH | Ensure audit log storage size is configured"
   lineinfile:
       dest: /etc/audit/auditd.conf
       regexp: "^max_log_file"
@@ -291,7 +301,17 @@
 - name: "SCORED | 4.1.13 | PATCH | Ensure successful file system mounts are collected"
   lineinfile:
       dest: /etc/audit/rules.d/audit.rules
+      line: "-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts"
       state: present
+  when: successful_file_system_mounts_collected_audit.rc
+  tags:
+      - level2
+      - patch
+      - rule_4.1.13
+
+- name: "SCORED | 4.1.13 | PATCH | Ensure successful file system mounts are collected"
+  lineinfile:
+      dest: /etc/audit/audit.rules
       line: "-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts"
       state: present
   when: successful_file_system_mounts_collected_audit.rc
@@ -303,7 +323,6 @@
 - name: "SCORED | 4.1.13 | PATCH | Ensure successful file system mounts are collected"
   lineinfile:
       dest: /etc/audit/rules.d/audit.rules
-      state: present
       line: "-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts"
       state: present
   when: successful_file_system_mounts_collected_audit.rc
@@ -345,7 +364,17 @@
 - name: "SCORED | 4.1.15 | PATCH | Ensure changes to system administration scope (sudoers) is collected"
   lineinfile:
       dest: /etc/audit/rules.d/audit.rules
+      line: "-w /etc/sudoers -p wa -k scope"
       state: present
+  when: change_to_system_administration_scope_collected_audit.rc
+  tags:
+      - level2
+      - patch
+      - rule_4.1.15
+
+- name: "SCORED | 4.1.15 | PATCH | Ensure changes to system administration scope (sudoers) is collected"
+  lineinfile:
+      dest: /etc/audit/audit.rules
       line: "-w /etc/sudoers -p wa -k scope"
       state: present
   when: change_to_system_administration_scope_collected_audit.rc
@@ -357,7 +386,6 @@
 - name: "SCORED | 4.1.15 | PATCH | Ensure changes to system administration scope (sudoers) is collected"
   lineinfile:
       dest: /etc/audit/rules.d/audit.rules
-      state: present
       line: "-w /etc/sudoers.d -p wa -k scope"
       state: present
   when: change_to_system_administration_scope_collected_audit.rc

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -120,6 +120,18 @@
       - rule_4.1.3
 
 - name: "SCORED | 4.1.3 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
+  copy:
+    src: grub
+    dest: /etc/default/grub
+    owner: root
+    group: root
+  when: audit_for_processes_prior_to_auditd_audit.rc
+  tags:
+      - level2
+      - patch
+      - rule_4.1.3
+
+- name: "SCORED | 4.1.3 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
   shell: sed -i 's/\(GRUB_CMDLINE_LINUX=.*\)\"$/\1 audit=1"/' /etc/default/grub && grub2-mkconfig > /boot/grub2/grub.cfg
   when: audit_for_processes_prior_to_auditd_audit.rc
   tags:

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -459,7 +459,7 @@
       - patch
       - rule_4.1.18
 
-- name: "SCORED | 4.2.1.1 | AUDIT | Ensure rsyslog Service is enabled"
+- name: "SCORED | 4.2.1.1 | AUDIT | command: /bin/true"
   command: systemctl is-enabled rsyslog
   register: rsyslog_service_enabled_audit
   always_run: yes
@@ -472,9 +472,7 @@
       - rule_4.2.1.1
 
 - name: "SCORED | 4.2.1.1 | PATCH | Ensure rsyslog Service is enabled"
-  service:
-    name: rsyslog
-    enabled: yes
+  command: /bin/true
   when: rsyslog_service_enabled_audit.rc
   tags:
       - level1
@@ -515,10 +513,7 @@
       - rule_4.2.1.3
 
 - name: "SCORED | 4.2.1.3 | PATCH | Ensure rsyslog default file permissions configured"
-  lineinfile:
-      dest: /etc/rsyslog.conf
-      state: present
-      line: "$FileCreateMode 0640"
+  command: /bin/true
   when: rsyslog_default_file_permissions_audit.rc
   tags:
       - level1
@@ -560,10 +555,7 @@
       - rule_4.2.1.5
 
 - name: "NOTSCORED | 4.2.1.5 | PATCH | Ensure remote rsyslog messages are only accepted on designated log hosts."
-  lineinfile:
-      dest: /etc/rsyslog.conf
-      state: absent
-      line: "$ModLoad imtcp.so"
+  command: /bin/true
   when: remote_rsyslog_messages_only_accepted_on_loghost_audit.rc
   tags:
       - level1
@@ -572,10 +564,7 @@
       - rule_4.2.1.5
 
 - name: "NOTSCORED | 4.2.1.5 | PATCH | Ensure remote rsyslog messages are only accepted on designated log hosts."
-  lineinfile:
-      dest: /etc/rsyslog.conf
-      state: absent
-      line: "$InputTCPServerRun 514"
+  command: /bin/true
   when: remote_rsyslog_messages_only_accepted_on_loghost_audit.rc
   tags:
       - level1

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -90,8 +90,8 @@
 
 - name: "SCORED | 4.1.2 | PATCH | Ensure auditd service is enabled"
   service:
-    name: auditd
-    enabled: yes
+      name: auditd
+      enabled: yes
   when: auditd_service_enabled_audit.rc
   tags:
       - level2

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -413,14 +413,6 @@
       - patch
       - rule_4.1.16
 
-- name: "SCORED | 4.1.16 | PATCH | Ensure system administrator actions (sudolog) are collected"
-  command: /bin/true
-  when: system_administrator_actions_audit.rc
-  tags:
-      - level2
-      - patch
-      - rule_4.1.16
-
 - name: "SCORED | 4.1.17 | AUDIT | Ensure kernel module loading and unloading is collected"
   command: grep modules /etc/audit/audit.rules
   register: kernel_module_loading_unloading_collected_audit

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -110,29 +110,7 @@
       - rule_4.1.3
 
 - name: "SCORED | 4.1.3 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
-  yum:
-    name: grub2-tools
-    state: present
-  when: audit_for_processes_prior_to_auditd_audit.rc
-  tags:
-      - level2
-      - patch
-      - rule_4.1.3
-
-- name: "SCORED | 4.1.3 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
-  copy:
-    src: grub
-    dest: /etc/default/grub
-    owner: root
-    group: root
-  when: audit_for_processes_prior_to_auditd_audit.rc
-  tags:
-      - level2
-      - patch
-      - rule_4.1.3
-
-- name: "SCORED | 4.1.3 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
-  shell: sed -i 's/\(GRUB_CMDLINE_LINUX=.*\)\"$/\1 audit=1"/' /etc/default/grub && grub2-mkconfig > /boot/grub2/grub.cfg
+  command: /bin/true
   when: audit_for_processes_prior_to_auditd_audit.rc
   tags:
       - level2

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -110,6 +110,16 @@
       - rule_4.1.3
 
 - name: "SCORED | 4.1.3 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
+  yum:
+    name: grub2-tools
+    state: present
+  when: audit_for_processes_prior_to_auditd_audit.rc
+  tags:
+      - level2
+      - patch
+      - rule_4.1.3
+
+- name: "SCORED | 4.1.3 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
   shell: sed -i 's/\(GRUB_CMDLINE_LINUX=.*\)\"$/\1 audit=1"/' /etc/default/grub && grub2-mkconfig > /boot/grub2/grub.cfg
   when: audit_for_processes_prior_to_auditd_audit.rc
   tags:

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -1,6 +1,6 @@
 - name: "NOTSCORED | 4.1.1.1 | AUDIT | Ensure audit log storage size is configured"
-  command: /bin/true
-  register: result
+  command: grep max_log_file /etc/audit/auditd.conf
+  register: audit_log_storage_size_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -10,15 +10,20 @@
       - rule_4.1.1.1
 
 - name: "NOTSCORED | 4.1.1.1 | PATCH | Ensure audit log storage size is configured"
-  command: /bin/true
+  lineinfile:
+      dest: /etc/audit/auditd.conf
+      regexp: "^max_log_file"
+      line: "max_log_file = 10"
+      state: present
+  when: audit_log_storage_size_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.1.1
 
 - name: "SCORED | 4.1.1.2 | AUDIT | Ensure system is disabled when audit logs are full"
-  command: /bin/true
-  register: result
+  shell: grep admin_space_left_action /etc/audit/auditd.conf | grep -i halt
+  register: audit_logs_full_action_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -28,15 +33,20 @@
       - rule_4.1.1.2
 
 - name: "SCORED | 4.1.1.2 | PATCH | Ensure system is disabled when audit logs are full"
-  command: /bin/true
+  lineinfile:
+      dest: /etc/audit/auditd.conf
+      regexp: "^admin_space_left_action"
+      line: "admin_space_left_action = halt"
+      state: present
+  when: audit_logs_full_action_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.1.2
 
 - name: "SCORED | 4.1.1.3 | AUDIT | Ensure audit logs are not automatically deleted"
-  command: /bin/true
-  register: result
+  shell: grep max_log_file_action /etc/audit/auditd.conf | grep -i keep_logs
+  register: audit_logs_kept_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -46,15 +56,20 @@
       - rule_4.1.1.3
 
 - name: "SCORED | 4.1.1.3 | PATCH | Ensure audit logs are not automatically deleted"
-  command: /bin/true
+  lineinfile:
+      dest: /etc/audit/auditd.conf
+      regexp: "^max_log_file_action"
+      line: "max_log_file_action = keep_logs"
+      state: present
+  when: audit_logs_kept_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.1.3
 
 - name: "SCORED | 4.1.2 | AUDIT | Ensure auditd service is enabled"
-  command: /bin/true
-  register: result
+  shell: "systemctl is-enabled auditd | grep enabled"
+  register: auditd_service_enabled_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -64,15 +79,18 @@
       - rule_4.1.2
 
 - name: "SCORED | 4.1.2 | PATCH | Ensure auditd service is enabled"
-  command: /bin/true
+  service:
+    name: auditd
+    enabled: yes
+  when: auditd_service_enabled_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.2
 
 - name: "SCORED | 4.1.3 | AUDIT | Ensure auditing for processes that start prior to auditd is enabled"
-  command: /bin/true
-  register: result
+  shell: grep "^\s*linux" /boot/grub2/grub.cfg|grep audit=1
+  register: audit_for_processes_prior_to_auditd_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -82,15 +100,16 @@
       - rule_4.1.3
 
 - name: "SCORED | 4.1.3 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
-  command: /bin/true
+  shell: sed -i 's/\(GRUB_CMDLINE_LINUX=.*\)\"$/\1 audit=1"/' /etc/default/grub && grub2-mkconfig > /boot/grub2/grub.cfg
+  when: audit_for_processes_prior_to_auditd_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.3
 
 - name: "SCORED | 4.1.4 | AUDIT | Ensure events that modify date and time information are collected"
-  command: /bin/true
-  register: result
+  command: grep time-change /etc/audit/audit.rules
+  register: data_and_time_changes_are_collected_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -101,14 +120,15 @@
 
 - name: "SCORED | 4.1.4 | PATCH | Ensure events that modify date and time information are collected"
   command: /bin/true
+  when: data_and_time_changes_are_collected_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.4
 
 - name: "SCORED | 4.1.5 | AUDIT | Ensure events that modify user/group information are collected"
-  command: /bin/true
-  register: result
+  command: grep identity /etc/audit/audit.rules
+  register: events_that_modify_user_group_info_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -119,14 +139,15 @@
 
 - name: "SCORED | 4.1.5 | PATCH | Ensure events that modify user/group information are collected"
   command: /bin/true
+  when: events_that_modify_user_group_info_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.5
 
 - name: "SCORED | 4.1.6 | AUDIT | Ensure events that modify the system's network environment are collected"
-  command: /bin/true
-  register: result
+  command: grep system-locale /etc/audit/audit.rules
+  register: events_modifying_network_environment_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -137,14 +158,15 @@
 
 - name: "SCORED | 4.1.6 | PATCH | Ensure events that modify the system's network environment are collected"
   command: /bin/true
+  when: events_modifying_network_environment_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.6
 
 - name: "SCORED | 4.1.7 | AUDIT | Ensure events that modify the system's Mandatory Access Controls are collected"
-  command: /bin/true
-  register: result
+  command: grep MAC-policy /etc/audit/audit.rules
+  register: events_modifying_system_macs_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -155,14 +177,15 @@
 
 - name: "SCORED | 4.1.7 | PATCH | Ensure events that modify the system's Mandatory Access Controls are collected"
   command: /bin/true
+  when: events_modifying_system_macs_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.7
 
 - name: "SCORED | 4.1.8 | AUDIT | Ensure login and logout events are collected"
-  command: /bin/true
-  register: result
+  command: grep logins /etc/audit/audit.rules
+  register: login_events_collected_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -173,14 +196,15 @@
 
 - name: "SCORED | 4.1.8 | PATCH | Ensure login and logout events are collected"
   command: /bin/true
+  when: login_events_collected_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.8
 
 - name: "SCORED | 4.1.9 | AUDIT | Ensure session initiation information is collected"
-  command: /bin/true
-  register: result
+  command: grep session /etc/audit/audit.rules
+  register: session_initiation_information_collected
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -191,14 +215,15 @@
 
 - name: "SCORED | 4.1.9 | PATCH | Ensure session initiation information is collected"
   command: /bin/true
+  when: session_initiation_information_collected.rc
   tags:
       - level2
       - patch
       - rule_4.1.9
 
 - name: "SCORED | 4.1.10 | AUDIT | Ensure discretionary access control permission modification events are collected"
-  command: /bin/true
-  register: result
+  command: grep perm_mod /etc/audit/audit.rules
+  register: access_control_permission_modifications_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -209,14 +234,15 @@
 
 - name: "SCORED | 4.1.10 | PATCH | Ensure discretionary access control permission modification events are collected"
   command: /bin/true
+  when: access_control_permission_modifications_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.10
 
 - name: "SCORED | 4.1.11 | AUDIT | Ensure unsuccessful unauthorized file access attempts are collected"
-  command: /bin/true
-  register: result
+  command: grep access /etc/audit/audit.rules
+  register: unsuccessful_unauthorized_file_access_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -227,6 +253,7 @@
 
 - name: "SCORED | 4.1.11 | PATCH | Ensure unsuccessful unauthorized file access attempts are collected"
   command: /bin/true
+  when: unsuccessful_unauthorized_file_access_audit.rc
   tags:
       - level2
       - patch
@@ -251,8 +278,8 @@
       - rule_4.1.12
 
 - name: "SCORED | 4.1.13 | AUDIT | Ensure successful file system mounts are collected"
-  command: /bin/true
-  register: result
+  command: grep mounts /etc/audit/audit.rules
+  register: successful_file_system_mounts_collected_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -262,15 +289,32 @@
       - rule_4.1.13
 
 - name: "SCORED | 4.1.13 | PATCH | Ensure successful file system mounts are collected"
-  command: /bin/true
+  lineinfile:
+      dest: /etc/audit/rules.d/audit.rules
+      state: present
+      line: "-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts"
+      state: present
+  when: successful_file_system_mounts_collected_audit.rc
+  tags:
+      - level2
+      - patch
+      - rule_4.1.13
+
+- name: "SCORED | 4.1.13 | PATCH | Ensure successful file system mounts are collected"
+  lineinfile:
+      dest: /etc/audit/rules.d/audit.rules
+      state: present
+      line: "-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts"
+      state: present
+  when: successful_file_system_mounts_collected_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.13
 
 - name: "SCORED | 4.1.14 | AUDIT | Ensure file deletion events by users are collected"
-  command: /bin/true
-  register: result
+  command: grep delete /etc/audit/audit.rules
+  register: file_deletion_events_are_collected_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -281,14 +325,15 @@
 
 - name: "SCORED | 4.1.14 | PATCH | Ensure file deletion events by users are collected"
   command: /bin/true
+  when: file_deletion_events_are_collected_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.14
 
 - name: "SCORED | 4.1.15 | AUDIT | Ensure changes to system administration scope (sudoers) is collected"
-  command: /bin/true
-  register: result
+  command: grep scope /etc/audit/audit.rules
+  register: change_to_system_administration_scope_collected_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -298,15 +343,32 @@
       - rule_4.1.15
 
 - name: "SCORED | 4.1.15 | PATCH | Ensure changes to system administration scope (sudoers) is collected"
-  command: /bin/true
+  lineinfile:
+      dest: /etc/audit/rules.d/audit.rules
+      state: present
+      line: "-w /etc/sudoers -p wa -k scope"
+      state: present
+  when: change_to_system_administration_scope_collected_audit.rc
+  tags:
+      - level2
+      - patch
+      - rule_4.1.15
+
+- name: "SCORED | 4.1.15 | PATCH | Ensure changes to system administration scope (sudoers) is collected"
+  lineinfile:
+      dest: /etc/audit/rules.d/audit.rules
+      state: present
+      line: "-w /etc/sudoers.d -p wa -k scope"
+      state: present
+  when: change_to_system_administration_scope_collected_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.15
 
 - name: "SCORED | 4.1.16 | AUDIT | Ensure system administrator actions (sudolog) are collected"
-  command: /bin/true
-  register: result
+  command: grep actions /etc/audit/audit.rules
+  register: system_administrator_actions_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -317,14 +379,23 @@
 
 - name: "SCORED | 4.1.16 | PATCH | Ensure system administrator actions (sudolog) are collected"
   command: /bin/true
+  when: system_administrator_actions_audit.rc
+  tags:
+      - level2
+      - patch
+      - rule_4.1.16
+
+- name: "SCORED | 4.1.16 | PATCH | Ensure system administrator actions (sudolog) are collected"
+  command: /bin/true
+  when: system_administrator_actions_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.16
 
 - name: "SCORED | 4.1.17 | AUDIT | Ensure kernel module loading and unloading is collected"
-  command: /bin/true
-  register: result
+  command: grep modules /etc/audit/audit.rules
+  register: kernel_module_loading_unloading_collected_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -335,14 +406,15 @@
 
 - name: "SCORED | 4.1.17 | PATCH | Ensure kernel module loading and unloading is collected"
   command: /bin/true
+  when: kernel_module_loading_unloading_collected_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.17
 
 - name: "SCORED | 4.1.18 | AUDIT | Ensure the audit configuration is immutable"
-  command: /bin/true
-  register: result
+  shell: grep "^\s*[^#]" /etc/audit/audit.rules | tail -1 | grep '\-e 2'
+  register: audit_configuration_immutable_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -353,14 +425,15 @@
 
 - name: "SCORED | 4.1.18 | PATCH | Ensure the audit configuration is immutable"
   command: /bin/true
+  when: audit_configuration_immutable_audit.rc
   tags:
       - level2
       - patch
       - rule_4.1.18
 
 - name: "SCORED | 4.2.1.1 | AUDIT | Ensure rsyslog Service is enabled"
-  command: /bin/true
-  register: result
+  command: systemctl is-enabled rsyslog
+  register: rsyslog_service_enabled_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -371,7 +444,10 @@
       - rule_4.2.1.1
 
 - name: "SCORED | 4.2.1.1 | PATCH | Ensure rsyslog Service is enabled"
-  command: /bin/true
+  service:
+    name: rsyslog
+    enabled: yes
+  when: rsyslog_service_enabled_audit.rc
   tags:
       - level1
       - level2
@@ -399,8 +475,8 @@
       - rule_4.2.1.2
 
 - name: "SCORED | 4.2.1.3 | AUDIT | Ensure rsyslog default file permissions configured"
-  command: /bin/true
-  register: result
+  command: grep ^\$FileCreateMode /etc/rsyslog.conf
+  register: rsyslog_default_file_permissions_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -411,7 +487,11 @@
       - rule_4.2.1.3
 
 - name: "SCORED | 4.2.1.3 | PATCH | Ensure rsyslog default file permissions configured"
-  command: /bin/true
+  lineinfile:
+      dest: /etc/rsyslog.conf
+      state: present
+      line: "$FileCreateMode 0640"
+  when: rsyslog_default_file_permissions_audit.rc
   tags:
       - level1
       - level2
@@ -419,8 +499,8 @@
       - rule_4.2.1.3
 
 - name: "SCORED | 4.2.1.4 | AUDIT | Ensure rsyslog is configured to send logs to a remote log host"
-  command: /bin/true
-  register: result
+  command: grep "^*.*[^I][^I]*@" /etc/rsyslog.conf
+  register: rsyslog_configured_to_send_logs_to_remote_loghost_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -432,6 +512,7 @@
 
 - name: "SCORED | 4.2.1.4 | PATCH | Ensure rsyslog is configured to send logs to a remote log host"
   command: /bin/true
+  when: rsyslog_configured_to_send_logs_to_remote_loghost_audit.rc
   tags:
       - level1
       - level2
@@ -439,8 +520,8 @@
       - rule_4.2.1.4
 
 - name: "NOTSCORED | 4.2.1.5 | AUDIT | Ensure remote rsyslog messages are only accepted on designated log hosts."
-  command: /bin/true
-  register: result
+  shell: grep -e '$ModLoad imtcp.so' -e '$InputTCPServerRun' /etc/rsyslog.conf | grep '#'
+  register: remote_rsyslog_messages_only_accepted_on_loghost_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -451,7 +532,23 @@
       - rule_4.2.1.5
 
 - name: "NOTSCORED | 4.2.1.5 | PATCH | Ensure remote rsyslog messages are only accepted on designated log hosts."
-  command: /bin/true
+  lineinfile:
+      dest: /etc/rsyslog.conf
+      state: absent
+      line: "$ModLoad imtcp.so"
+  when: remote_rsyslog_messages_only_accepted_on_loghost_audit.rc
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_4.2.1.5
+
+- name: "NOTSCORED | 4.2.1.5 | PATCH | Ensure remote rsyslog messages are only accepted on designated log hosts."
+  lineinfile:
+      dest: /etc/rsyslog.conf
+      state: absent
+      line: "$InputTCPServerRun 514"
+  when: remote_rsyslog_messages_only_accepted_on_loghost_audit.rc
   tags:
       - level1
       - level2
@@ -459,8 +556,8 @@
       - rule_4.2.1.5
 
 - name: "SCORED | 4.2.2.1 | AUDIT | Ensure syslog-ng service is enabled"
-  command: /bin/true
-  register: result
+  command: systemctl is-enabled syslog-ng
+  register: syslog_ng_is_enabled_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -480,6 +577,7 @@
 
 - name: "NOTSCORED | 4.2.2.2 | AUDIT | Ensure logging is configured"
   command: /bin/true
+  when: syslog_ng_is_enabled_audit.rc == '0'
   register: result
   always_run: yes
   changed_when: no
@@ -492,6 +590,7 @@
 
 - name: "NOTSCORED | 4.2.2.2 | PATCH | Ensure logging is configured"
   command: /bin/true
+  when: syslog_ng_is_enabled_audit.rc == '0'
   tags:
       - level1
       - level2
@@ -500,6 +599,7 @@
 
 - name: "SCORED | 4.2.2.3 | AUDIT | Ensure syslog-ng default file permissions configured"
   command: /bin/true
+  when: syslog_ng_is_enabled_audit.rc == '0'
   register: result
   always_run: yes
   changed_when: no
@@ -512,6 +612,7 @@
 
 - name: "SCORED | 4.2.2.3 | PATCH | Ensure syslog-ng default file permissions configured"
   command: /bin/true
+  when: syslog_ng_is_enabled_audit.rc == '0'
   tags:
       - level1
       - level2
@@ -520,6 +621,7 @@
 
 - name: "NOTSCORED | 4.2.2.4 | AUDIT | Ensure syslog-ng is configured to send logs to a remote log host"
   command: /bin/true
+  when: syslog_ng_is_enabled_audit.rc == '0'
   register: result
   always_run: yes
   changed_when: no
@@ -532,6 +634,7 @@
 
 - name: "NOTSCORED | 4.2.2.4 | PATCH | Ensure syslog-ng is configured to send logs to a remote log host"
   command: /bin/true
+  when: syslog_ng_is_enabled_audit.rc == '0'
   tags:
       - level1
       - level2
@@ -540,6 +643,7 @@
 
 - name: "NOTSCORED | 4.2.2.5 | AUDIT | Ensure remote syslog-ng messages are only accepted on designated log hosts"
   command: /bin/true
+  when: syslog_ng_is_enabled_audit.rc == '0'
   register: result
   always_run: yes
   changed_when: no
@@ -552,6 +656,7 @@
 
 - name: "NOTSCORED | 4.2.2.5 | PATCH | Ensure remote syslog-ng messages are only accepted on designated log hosts"
   command: /bin/true
+  when: syslog_ng_is_enabled_audit.rc == '0'
   tags:
       - level1
       - level2
@@ -559,9 +664,21 @@
       - rule_4.2.2.5
 
 - name: "SCORED | 4.2.3 | AUDIT | Ensure rsyslog or syslog-ng is installed"
-  command: /bin/true
-  register: result
+  command: rpm -q rsyslog
+  register: rsyslog_is_installed_audit
   always_run: yes
+  changed_when: no
+  ignore_errors: yes
+  tags:
+      - level1
+      - level2
+      - audit
+      - rule_4.2.3
+
+- name: "SCORED | 4.2.3 | AUDIT | Ensure rsyslog or syslog-ng is installed"
+  command: rpm -q syslog-ng
+  register: syslog_ng_is_installed
+  when: rsyslog_is_installed_audit.rc
   changed_when: no
   ignore_errors: yes
   tags:
@@ -572,6 +689,7 @@
 
 - name: "SCORED | 4.2.3 | PATCH | Ensure rsyslog or syslog-ng is installed"
   command: /bin/true
+  when: syslog_ng_is_enabled_audit.rc or rsyslog_is_installed_audit.rc
   tags:
       - level1
       - level2
@@ -579,8 +697,8 @@
       - rule_4.2.3
 
 - name: "SCORED | 4.2.4 | AUDIT | Ensure permissions on all logfiles are configured"
-  command: /bin/true
-  register: result
+  command: find /var/log -type f -perm /o+r
+  register: permissions_on_logfiles_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -591,7 +709,8 @@
       - rule_4.2.4
 
 - name: "SCORED | 4.2.4 | PATCH | Ensure permissions on all logfiles are configured"
-  command: /bin/true
+  command: find /var/log -type f -exec chmod g-wx,o-rwx {} +
+  when: permissions_on_logfiles_audit.rc
   tags:
       - level1
       - level2

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -11,9 +11,21 @@
       - rule_5.1.1
 
 - name: "SCORED | 5.1.1 | PATCH | Ensure cron daemon is enabled"
+  yum:
+      name: cronie
+      state: present
+  when: cron_daemon_enabled_audit.rc
+  tags:
+      - level1
+      - level2
+      - patch
+      - rule_5.1.1
+
+- name: "SCORED | 5.1.1 | PATCH | Ensure cron daemon is enabled"
   service:
       name: crond
       enabled: yes
+  when: cron_daemon_enabled_audit.rc
   tags:
       - level1
       - level2

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -300,8 +300,9 @@
   lineinfile:
       state: present
       dest: /etc/ssh/sshd_config
-      regexp: '^(#)?Protocol \d'
+      regexp: '^Protocol'
       line: 'Protocol 2'
+  when: ssh_protocol2_audit.rc
   tags:
       - level1
       - level2
@@ -324,8 +325,9 @@
   lineinfile:
       state: present
       dest: /etc/ssh/sshd_config
-      regexp: '^(#)?LogLevel INFO\d'
+      regexp: '^LogLevel'
       line: 'LogLevel INFO'
+  when: ssh_loglevel_audit.rc
   tags:
       - level1
       - level2
@@ -348,8 +350,9 @@
   lineinfile:
       state: present
       dest: /etc/ssh/sshd_config
-      regexp: '^(#)?X11Forwarding \d'
+      regexp: '^X11Forwarding'
       line: 'X11Forwarding no'
+  when: ssh_x11_forwarding_audit.rc
   tags:
       - level1
       - level2
@@ -374,6 +377,7 @@
       dest: /etc/ssh/sshd_config
       regexp: '^(#)?MaxAuthTries \d'
       line: 'MaxAuthTries 4'
+  when: ssh_max_auth_tries_audit.rc
   tags:
       - level1
       - level2
@@ -398,6 +402,7 @@
       dest: /etc/ssh/sshd_config
       regexp: '^IgnoreRhosts'
       line: 'IgnoreRhosts yes'
+  when: ssh_ignore_rhosts_audit.rc
   tags:
       - level1
       - level2
@@ -422,6 +427,7 @@
       dest: /etc/ssh/sshd_config
       regexp: '^HostbasedAuthentication'
       line: 'HostbasedAuthentication no'
+  when: ssh_hostbased_authentication_audit.rc
   tags:
       - level1
       - level2
@@ -446,6 +452,7 @@
       dest: /etc/ssh/sshd_config
       regexp: '^PermitRootLogin'
       line: 'PermitRootLogin no'
+  when: ssh_permit_root_login_audit.rc
   tags:
       - level1
       - level2
@@ -470,6 +477,7 @@
       dest: /etc/ssh/sshd_config
       regexp: '^PermitEmptyPasswords'
       line: 'PermitEmptyPasswords no'
+  when: ssh_permit_empty_passwords_audit.rc
   tags:
       - level1
       - level2
@@ -494,6 +502,7 @@
       dest: /etc/ssh/sshd_config
       regexp: '^PermitUserEnvironment'
       line: 'PermitUserEnvironment no'
+  when: ssh_permit_userenvironment_audit.rc
   tags:
       - level1
       - level2
@@ -518,6 +527,7 @@
       dest: /etc/ssh/sshd_config
       regexp: '^Ciphers'
       line: 'Ciphers aes128-ctr,aes192-ctr,aes256-ctr'
+  when: ssh_approved_cyphers_audit.rc
   tags:
       - level1
       - level2
@@ -525,8 +535,8 @@
       - rule_5.2.11
 
 - name: "SCORED | 5.2.12 | AUDIT | Ensure only approved MAC algorithms are used"
-  command: /bin/true
-  register: result
+  command: grep "MACs" /etc/ssh/sshd_config
+  register: ssh_only_approved_macs_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -537,7 +547,12 @@
       - rule_5.2.12
 
 - name: "SCORED | 5.2.12 | PATCH | Ensure only approved MAC algorithms are used"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^MACs'
+      line: 'MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com'
+  when: ssh_only_approved_macs_audit.rc
   tags:
       - level1
       - level2
@@ -545,7 +560,7 @@
       - rule_5.2.12
 
 - name: "SCORED | 5.2.13 | AUDIT | Ensure SSH Idle Timeout Interval is configured"
-  command: grep "^ClientAliveInterval" /etc/ssh/sshd_confige
+  command: grep "^ClientAliveInterval" /etc/ssh/sshd_config
   register: ssh_idle_timeout_audit
   always_run: yes
   changed_when: no
@@ -562,6 +577,7 @@
       dest: /etc/ssh/sshd_config
       regexp: '^ClientAliveInterval'
       line: 'ClientAliveInterval 300'
+  when: ssh_idle_timeout_audit.rc
   tags:
       - level1
       - level2
@@ -569,8 +585,8 @@
       - rule_5.2.13
 
 - name: "SCORED | 5.2.14 | AUDIT | Ensure SSH LoginGraceTime is set to one minute or less"
-  command: /bin/true
-  register: result
+  command: grep "^LoginGraceTime" /etc/ssh/sshd_config
+  register: ssh_logingracetime_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -581,7 +597,12 @@
       - rule_5.2.14
 
 - name: "SCORED | 5.2.14 | PATCH | Ensure SSH LoginGraceTime is set to one minute or less"
-  command: /bin/true
+  lineinfile:
+      state: present
+      dest: /etc/ssh/sshd_config
+      regexp: '^LoginGraceTime'
+      line: 'LoginGraceTime 60'
+  when: ssh_logingracetime_audit.rc
   tags:
       - level1
       - level2
@@ -691,8 +712,8 @@
       - rule_5.3.2
 
 - name: "SCORED | 5.3.3 | AUDIT | Ensure password reuse is limited"
-  command: /bin/true
-  register: result
+  shell: egrep '^password\s+sufficient\s+pam_unix.so' /etc/pam.d/password-auth|grep remember
+  register: pam_password_reuse_is_limited
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -704,6 +725,7 @@
 
 - name: "SCORED | 5.3.3 | PATCH | Ensure password reuse is limited"
   command: /bin/true
+  when: pam_password_reuse_is_limited.rc
   tags:
       - level1
       - level2
@@ -724,6 +746,7 @@
 
 - name: "SCORED | 5.3.4 | PATCH | Ensure password hashing algorithm is SHA-512"
   command: authconfig --passalgo=sha512 --update
+  when: pass_sha512_hashing_audit.rc
   tags:
       - level1
       - level2
@@ -843,8 +866,8 @@
       - rule_5.4.2
 
 - name: "SCORED | 5.4.3 | AUDIT | Ensure default group for the root account is GID 0"
-  command: /bin/true
-  register: result
+  shell: 'grep "^root:" /etc/passwd | cut -f4 -d: | grep 0'
+  register: default_group_for_root_is_gid_0_audit
   always_run: yes
   changed_when: no
   ignore_errors: yes
@@ -855,7 +878,8 @@
       - rule_5.4.3
 
 - name: "SCORED | 5.4.3 | PATCH | Ensure default group for the root account is GID 0"
-  command: /bin/true
+  command: usermod -g 0 root
+  when: default_group_for_root_is_gid_0_audit.rc
   tags:
       - level1
       - level2

--- a/tests/Dockerfile.centos-7
+++ b/tests/Dockerfile.centos-7
@@ -13,7 +13,7 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 # Install Ansible
-RUN yum -y install epel-release
+RUN yum -y install epel-release openssh-server audit
 RUN yum -y install git ansible sudo
 RUN yum clean all
 

--- a/tests/Dockerfile.centos-7
+++ b/tests/Dockerfile.centos-7
@@ -13,7 +13,7 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 # Install Ansible
-RUN yum -y install epel-release openssh-server audit
+RUN yum -y install epel-release openssh-server audit authconfig
 RUN yum -y install git ansible sudo
 RUN yum clean all
 


### PR DESCRIPTION
I paid most attention to AUDIT actions, yet implemented some PATCH actions too. I think the patch should be conditional on the AUDIT, quite often the audit is a grep and the patch can use:
when: var_audit.rc

This results in a colored log for repeated rune where implemented patches are skipped and blue, where the unimplemented patches are yellow.
