### PR TITLE
4.1.3 Ensure auditing for processes that start prior to auditd is enabled

### DIFF
--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -47,7 +47,13 @@
       - rule_4.1.2
 
 - name: "SCORED | 4.1.3 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
-  command: /bin/true
+  replace:
+      dest: /etc/default/grub
+      regexp: '(^GRUB_CMDLINE_LINUX\s*\=\s*)(?:")(.+)(?<!audit=1)(?:")'
+      replace: '\1"\2 audit=1"'
+      follow: yes
+  ignore_errors: yes
+  notify: generate new grub config
   tags:
       - level2
       - auditd


### PR DESCRIPTION
Not sure this is the most elegant way to implement this control, but this uses a negative look behind regexp to make sure that the audit=1 string is in the boot parameters list.  In my testing it does the right thing and is idempotent.