### PR TITLE
Issue #17 xinetd services

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,9 @@ rhel7cis_squid: false
 rhel7cis_net_snmp: false
 rhel7cis_allow_autofs: false
 
+# xinetd required
+rhel7cis_xinetd_required: false
+
 # RedHat Satellite Subscription items
 rhel7cis_rhnsd_required: false
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -32,4 +32,6 @@
 
 - name: restart xinetd
   become: yes
-  shell: kill -USR2 `pidof xinetd`
+  service:
+        name: xinetd
+        state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -32,4 +32,4 @@
 
 - name: restart xinetd
   become: yes
-  command: "kill -USR2 `pidof xinetd`"
+  shell: kill -USR2 `pidof xinetd`

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -29,3 +29,7 @@
 - name: generate new grub config
   become: yes
   shell: grub2-mkconfig -o {{ grub_cfg.stat.lnk_source }}
+
+- name: restart xinetd
+  become: yes
+  command: "kill -USR2 `pidof xinetd`"

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -10,10 +10,8 @@
       - rule_2.1.1
 
 - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram"
-  service:
-      name: chargen-dgram
-      state: stopped
-      enabled: no
+  command: chkconfig chargen-dgram off
+  notify: restart xinetd
   when: chargen_dgram_service.stat.exists
   tags:
       - level1
@@ -34,10 +32,8 @@
       - rule_2.1.1
 
 - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-stream"
-  service:
-      name: chargen-stream
-      state: stopped
-      enabled: no
+  command: chkconfig chargen-stream off
+  notify: restart xinetd
   when: chargen_stream_service.stat.exists
   tags:
       - level1
@@ -57,10 +53,8 @@
       - rule_2.1.2
 
 - name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-dgram"
-  service:
-      name: daytime-dgram
-      state: stopped
-      enabled: no
+  command: chkconfig daytime-dgram off
+  notify: restart xinetd
   when: daytime_dgram_service.stat.exists
   tags:
       - level1
@@ -79,10 +73,8 @@
       - rule_2.1.2
 
 - name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-stream"
-  service:
-      name: daytime-stream
-      state: stopped
-      enabled: no
+  command: chkconfig daytime-stream off
+  notify: restart xinetd
   when: daytime_stream_service.stat.exists
   tags:
       - level1
@@ -101,10 +93,8 @@
       - rule_2.1.3
 
 - name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-dgram"
-  service:
-      name: discard-dgram
-      state: stopped
-      enabled: no
+  command: chkconfig discard-dgram off
+  notify: restart xinetd
   when: discard_dgram_service.stat.exists
   tags:
       - level1
@@ -112,7 +102,7 @@
       - patch
       - rule_2.1.3
 
-- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled |Â discard-stream"
+- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
   stat:
       path: /etc/xinetd.d/discard-stream
   register: discard_stream_service
@@ -122,11 +112,9 @@
       - patch
       - rule_2.1.3
 
-- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled |Â discard-stream"
-  service:
-      name: discard-stream
-      state: stopped
-      enabled: no
+- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
+  command: chkconfig discard-stream off
+  notify: restart xinetd
   when: discard_stream_service.stat.exists
   tags:
       - level1
@@ -145,10 +133,8 @@
       - rule_2.1.4
 
 - name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-dgram"
-  service:
-      name: echo-dgram
-      state: stopped
-      enabled: no
+  command: chkconfig echo-dgram off
+  notify: restart xinetd
   when: echo_dgram_service.stat.exists
   tags:
       - level1
@@ -156,7 +142,7 @@
       - patch
       - rule_2.1.4
 
-- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled |Â echo-stream"
+- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
   stat:
       path: /etc/xinetd.d/echo-stream
   register: echo_stream_service
@@ -166,11 +152,9 @@
       - patch
       - rule_2.1.4
 
-- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled |Â echo-stream"
-  service:
-      name: echo-stream
-      state: stopped
-      enabled: no
+- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
+  command: chkconfig echo-stream off
+  notify: restart xinetd
   when: echo_stream_service.stat.exists
   tags:
       - level1
@@ -178,7 +162,7 @@
       - patch
       - rule_2.1.4
 
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled |Â time-dgram"
+- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
   stat:
       path: /etc/xinetd.d/time-dgram
   register: time_dgram_service
@@ -188,11 +172,9 @@
       - patch
       - rule_2.1.5
 
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled |Â time-dgram"
-  service:
-      name: time-dgram
-      state: stopped
-      enabled: no
+- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
+  command: chkconfig time-dgram off
+  notify: restart xinetd
   when: time_dgram_service.stat.exists
   tags:
       - level1
@@ -200,7 +182,7 @@
       - patch
       - rule_2.1.5
 
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled |Â time-stream"
+- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
   stat:
       path: /etc/xinetd.d/time-stream
   register: time_stream_service
@@ -210,11 +192,9 @@
       - patch
       - rule_2.1.5
 
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled |Â time-stream"
-  service:
-      name: time-stream
-      state: stopped
-      enabled: no
+- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
+  command: chkconfig time-stream off
+  notify: restart xinetd
   when: time_stream_service.stat.exists
   tags:
       - level1
@@ -233,10 +213,8 @@
       - rule_2.1.6
 
 - name: "SCORED | 2.1.6 | PATCH | Ensure tftp server is not enabled"
-  service:
-      name: tftp
-      state: stopped
-      enabled: no
+  command: chkconfig tftp off
+  notify: restart xinetd
   when: tftp_service.stat.exists and rhel7cis_tftp_server == false
   tags:
       - level1
@@ -249,7 +227,14 @@
       name: xinetd
       state: stopped
       enabled: no
-  when: xinetd_service_status.stdout == "loaded"
+  when: 
+      - xinetd_service_status.stdout == "loaded" 
+      - not rhel7cis_telnet_server
+      - not rhel7cis_vsftpd_server
+      - not rhel7cis_named_server
+      - not rhel7cis_tftp_server
+      - not rhel7cis_cups_server
+      - not rhel7cis_rsyncd_server
   tags:
       - level1
       - patch

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -228,13 +228,7 @@
       state: stopped
       enabled: no
   when: 
-      - xinetd_service_status.stdout == "loaded" 
-      - not rhel7cis_telnet_server
-      - not rhel7cis_vsftpd_server
-      - not rhel7cis_named_server
-      - not rhel7cis_tftp_server
-      - not rhel7cis_cups_server
-      - not rhel7cis_rsyncd_server
+      - xinetd_service_status.stdout == "loaded" and not rhel7cis_xinetd_required
   tags:
       - level1
       - patch

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -102,7 +102,7 @@
       - patch
       - rule_2.1.3
 
-- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
+- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
   stat:
       path: /etc/xinetd.d/discard-stream
   register: discard_stream_service
@@ -112,7 +112,7 @@
       - patch
       - rule_2.1.3
 
-- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
+- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
   command: chkconfig discard-stream off
   notify: restart xinetd
   when: discard_stream_service.stat.exists
@@ -142,7 +142,7 @@
       - patch
       - rule_2.1.4
 
-- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
+- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
   stat:
       path: /etc/xinetd.d/echo-stream
   register: echo_stream_service
@@ -152,7 +152,7 @@
       - patch
       - rule_2.1.4
 
-- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
+- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
   command: chkconfig echo-stream off
   notify: restart xinetd
   when: echo_stream_service.stat.exists
@@ -162,7 +162,7 @@
       - patch
       - rule_2.1.4
 
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
+- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
   stat:
       path: /etc/xinetd.d/time-dgram
   register: time_dgram_service
@@ -172,7 +172,7 @@
       - patch
       - rule_2.1.5
 
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
+- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
   command: chkconfig time-dgram off
   notify: restart xinetd
   when: time_dgram_service.stat.exists
@@ -182,7 +182,7 @@
       - patch
       - rule_2.1.5
 
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
+- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
   stat:
       path: /etc/xinetd.d/time-stream
   register: time_stream_service
@@ -192,7 +192,7 @@
       - patch
       - rule_2.1.5
 
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
+- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
   command: chkconfig time-stream off
   notify: restart xinetd
   when: time_stream_service.stat.exists
@@ -307,7 +307,7 @@
       - patch
       - rule_2.2.1.2
 
-- name: "SCORED | 2.2.1.2 | PATCH | Ensure ntp is configuredÂ |Â modify /usr/lib/systemd/system/ntpd.service"
+- name: "SCORED | 2.2.1.2 | PATCH | Ensure ntp is configured | modify /usr/lib/systemd/system/ntpd.service"
   lineinfile:
       dest: /usr/lib/systemd/system/ntpd.service
       regexp: "^(#)?ExecStart"
@@ -331,7 +331,7 @@
       - patch
       - rule_2.2.1.3
 
-- name: "SCORED | 2.2.1.3 | PATCH | Ensure chrony is configured | modify /etc/sysconfig/chronyd |Â 1"
+- name: "SCORED | 2.2.1.3 | PATCH | Ensure chrony is configured | modify /etc/sysconfig/chronyd | 1"
   lineinfile:
       dest: /etc/sysconfig/chronyd
       regexp: "^(#)?OPTIONS"


### PR DESCRIPTION
I think this will solve getting ansible to configure the xinetd-based services on RHEL7 where it looks like the service module defaults to only using systemctl on that OS.

Using the "command" module always registers as a change, which is unfortunate.  Maybe lineinfile would be a better way to do it looking for "disabled=yes" in the files, but it seems more bulletproof to use the actual command of "chkconfig <servicename> off".

Please let me know if these pull requests are useful or if I should knock it off. 8)  As you can tell I'm in pretty active development trying to get it up to production level for me.