### PR TITLE
Adding some firewalld config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -101,6 +101,9 @@ rhel7cis_host_allow:
 rhel7cis_firewall: firewalld
 #rhel7cis_firewall: iptables
 
+rhel7cis_firewall_services:
+    - ssh
+
 # Warning Banner Content (issue, issue.net, motd)
 rhel7cis_warning_banner: |
     Authorized uses only. All activity may be monitored and reported.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,6 +103,7 @@ rhel7cis_firewall: firewalld
 
 rhel7cis_firewall_services:
     - ssh
+    - dhcpv6-client
 
 # Warning Banner Content (issue, issue.net, motd)
 rhel7cis_warning_banner: |

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -29,3 +29,9 @@
 - name: generate new grub config
   become: yes
   shell: grub2-mkconfig -o {{ grub_cfg.stat.lnk_source }}
+
+- name: restart firewalld
+  become: yes
+  service:
+      name: firewalld
+      state: restarted

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -366,9 +366,9 @@
       - rule_3.6.1
 
 - name: "SCORED | 3.6.2 | PATCH | Ensure default deny firewall policy"
-  lineinfile: 
-      dest: /etc/firewalld/firewalld.conf 
-      regexp: "^DefaultZone" 
+  lineinfile:
+      dest: /etc/firewalld/firewalld.conf
+      regexp: "^DefaultZone"
       line: "DefaultZone=drop"
   when: rhel7cis_firewall == "firewalld"
   tags:
@@ -377,9 +377,9 @@
       - rule_3.6.2
 
 - name: "SCORED | 3.6.2 | PATCH | Ensure default deny firewall policy"
-  firewalld: 
-      state: enabled 
-      zone: drop 
+  firewalld:
+      state: enabled
+      zone: drop
       permanent: true
   when: rhel7cis_firewall == "firewalld"
   tags:
@@ -411,15 +411,16 @@
       - patch
       - rule_3.6.4
 
- name: "SCORED | 3.6.5 | PATCH | Ensure firewall rules exist for all open ports"
+- name: "SCORED | 3.6.5 | PATCH | Ensure firewall rules exist for all open ports"
   firewalld:
-      service: "{{ items}}"
+      service: "{{ item }}"
       state: enabled
       zone: drop
       permanent: true
       immediate: true
   when: rhel7cis_firewall == "firewalld"
-  with_items: rhel7cis_firewall_services
+  notify: restart firewalld
+  with_items: "{{ rhel7cis_firewall_services }}"
   tags:
       - level1
       - patch

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -336,8 +336,8 @@
 - name: "SCORED | 3.6 | PATCH | Ensure firewalld is installed and started | CUSTOM"
   service:
       name: firewalld
-      state: stopped
-      enabled: no
+      state: started
+      enabled: yes
   when: rhel7cis_firewall == "firewalld"
   tags:
       - level1
@@ -353,6 +353,39 @@
       - level1
       - patch
       - rule_3.6.1
+
+- name: "SCORED | 3.6.1 | PATCH | Ensure iptables is installed and started"
+  service:
+      name: iptables
+      state: started
+      enabled: yes
+  when: rhel7cis_firewall == "iptables"
+  tags:
+      - level1
+      - patch
+      - rule_3.6.1
+
+- name: "SCORED | 3.6.2 | PATCH | Ensure default deny firewall policy"
+  lineinfile: 
+      dest: /etc/firewalld/firewalld.conf 
+      regexp: "^DefaultZone" 
+      line: "DefaultZone=drop"
+  when: rhel7cis_firewall == "firewalld"
+  tags:
+      - level1
+      - patch
+      - rule_3.6.2
+
+- name: "SCORED | 3.6.2 | PATCH | Ensure default deny firewall policy"
+  firewalld: 
+      state: enabled 
+      zone: drop 
+      permanent: true
+  when: rhel7cis_firewall == "firewalld"
+  tags:
+      - level1
+      - patch
+      - rule_3.6.2
 
 - name: "SCORED | 3.6.2 | PATCH | Ensure default deny firewall policy"
   command: /bin/true
@@ -377,6 +410,20 @@
       - level1
       - patch
       - rule_3.6.4
+
+ name: "SCORED | 3.6.5 | PATCH | Ensure firewall rules exist for all open ports"
+  firewalld:
+      service: "{{ items}}"
+      state: enabled
+      zone: drop
+      permanent: true
+      immediate: true
+  when: rhel7cis_firewall == "firewalld"
+  with_items: rhel7cis_firewall_services
+  tags:
+      - level1
+      - patch
+      - rule_3.6.5
 
 - name: "SCORED | 3.6.5 | PATCH | Ensure firewall rules exist for all open ports"
   command: /bin/true


### PR DESCRIPTION
I added a firewalld services variable in defaults with the two that seem commonly needed.  We assume you'll need SSH because ansible uses it.  Might be appropriate to only do SSH, but strangely dhcpv6 does seem to need firewall open to get IP addresses and we're under a fed mandate to enable ipv6.

Also added a handler to restart firewalld.

Lastly, did firewalld config to set the default zone to drop as described in 3.6.2 and then add the services in the defaults file.  

This has the consequence of also disabling ping, which needs a special command to re-enable.

So we're using firewalld because RHEL7 enables it, but CIS specifically seems to require iptables in 3.6.1 and has no mention of firewalld.  What are your feelings about compliance using firewalld?