### PR TITLE
added on/off vars to all section2 tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,7 +75,41 @@ rhel7cis_rule_1_7_1_6: true
 rhel7cis_rule_1_7_2: true
 
 # Section 2 rules
-#rhel7cis_rule_2_1_1: true
+rhel7cis_rule_2_1_1: false
+rhel7cis_rule_2_1_2: true
+rhel7cis_rule_2_1_3: true
+rhel7cis_rule_2_1_4: true
+rhel7cis_rule_2_1_5: true
+rhel7cis_rule_2_1_6: true
+rhel7cis_rule_2_1_7: true
+rhel7cis_rule_2_2_1_1: true
+rhel7cis_rule_2_2_1_2: true
+rhel7cis_rule_2_2_1_3: true
+rhel7cis_rule_2_2_2: true
+rhel7cis_rule_2_2_3: true
+rhel7cis_rule_2_2_4: true
+rhel7cis_rule_2_2_5: true
+rhel7cis_rule_2_2_6: true
+rhel7cis_rule_2_2_7: true
+rhel7cis_rule_2_2_8: true
+rhel7cis_rule_2_2_9: true
+rhel7cis_rule_2_2_10: true
+rhel7cis_rule_2_2_11: true
+rhel7cis_rule_2_2_12: true
+rhel7cis_rule_2_2_13: true
+rhel7cis_rule_2_2_14: true
+rhel7cis_rule_2_2_15: true
+rhel7cis_rule_2_2_16: true
+rhel7cis_rule_2_2_17: true
+rhel7cis_rule_2_2_18: true
+rhel7cis_rule_2_2_19: true
+rhel7cis_rule_2_2_20: true
+rhel7cis_rule_2_2_21: true
+rhel7cis_rule_2_3_1: true
+rhel7cis_rule_2_3_2: true
+rhel7cis_rule_2_3_3: true
+rhel7cis_rule_2_3_4: true
+rhel7cis_rule_2_3_5: true
 
 # Section 3 rules
 #rhel7cis_rule_3_1_1: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,7 +75,7 @@ rhel7cis_rule_1_7_1_6: true
 rhel7cis_rule_1_7_2: true
 
 # Section 2 rules
-rhel7cis_rule_2_1_1: false
+rhel7cis_rule_2_1_1: true
 rhel7cis_rule_2_1_2: true
 rhel7cis_rule_2_1_3: true
 rhel7cis_rule_2_1_4: true

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -1,4 +1,4 @@
-- name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram"
+- name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram,chargen-stream"
   block:
       - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram"
         stat:

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -2,6 +2,8 @@
   stat:
       path: /etc/xinetd.d/chargen-dgram
   register: chargen_dgram_service
+  when:
+      - rhel7cis_rule_2_1_1
   tags:
       - level1
       - scored
@@ -12,7 +14,9 @@
 - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram"
   command: chkconfig chargen-dgram off
   notify: restart xinetd
-  when: chargen_dgram_service.stat.exists
+  when:
+      - chargen_dgram_service.skipped is not defined and chargen_dgram_service.stat.exists
+      - rhel7cis_rule_2_1_1
   tags:
       - level1
       - scored
@@ -24,6 +28,8 @@
   stat:
       path: /etc/xinetd.d/chargen-stream
   register: chargen_stream_service
+  when:
+      - rhel7cis_rule_2_1_1
   tags:
       - level1
       - scored
@@ -34,7 +40,9 @@
 - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-stream"
   command: chkconfig chargen-stream off
   notify: restart xinetd
-  when: chargen_stream_service.stat.exists
+  when:
+      - chargen_stream_service is not defined and chargen_stream_service.stat.exists
+      - rhel7cis_rule_2_1_1
   tags:
       - level1
       - scored
@@ -46,6 +54,8 @@
   stat:
       path: /etc/xinetd.d/daytime-dgram
   register: daytime_dgram_service
+  when:
+      - rhel7cis_rule_2_1_2
   tags:
       - level1
       - scored
@@ -55,7 +65,9 @@
 - name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-dgram"
   command: chkconfig daytime-dgram off
   notify: restart xinetd
-  when: daytime_dgram_service.stat.exists
+  when:
+      - daytime_dgram_service.skipped is not defined and daytime_dgram_service.stat.exists
+      - rhel7cis_rule_2_1_2
   tags:
       - level1
       - scored
@@ -66,6 +78,8 @@
   stat:
       path: /etc/xinetd.d/daytime-stream
   register: daytime_stream_service
+  when:
+      - rhel7cis_rule_2_1_2
   tags:
       - level1
       - scored
@@ -75,7 +89,9 @@
 - name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-stream"
   command: chkconfig daytime-stream off
   notify: restart xinetd
-  when: daytime_stream_service.stat.exists
+  when:
+      - daytime_stream_service.skipped is not defined and daytime_stream_service.stat.exists
+      - rhel7cis_rule_2_1_2
   tags:
       - level1
       - scored
@@ -86,6 +102,8 @@
   stat:
       path: /etc/xinetd.d/discard-dgram
   register: discard_dgram_service
+  when:
+      - rhel7cis_rule_2_1_3
   tags:
       - level1
       - scored
@@ -95,7 +113,9 @@
 - name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-dgram"
   command: chkconfig discard-dgram off
   notify: restart xinetd
-  when: discard_dgram_service.stat.exists
+  when:
+      - discard_dgram_service.skipped is not defined and discard_dgram_service.stat.exists
+      - rhel7cis_rule_2_1_3
   tags:
       - level1
       - scored
@@ -106,6 +126,8 @@
   stat:
       path: /etc/xinetd.d/discard-stream
   register: discard_stream_service
+  when:
+      - rhel7cis_rule_2_1_3
   tags:
       - level1
       - scored
@@ -115,7 +137,9 @@
 - name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
   command: chkconfig discard-stream off
   notify: restart xinetd
-  when: discard_stream_service.stat.exists
+  when:
+      - discard_stream_service.skipped is not defined and discard_stream_service.stat.exists
+      - rhel7cis_rule_2_1_3
   tags:
       - level1
       - scored
@@ -126,6 +150,8 @@
   stat:
       path: /etc/xinetd.d/echo-dgram
   register: echo_dgram_service
+  when:
+      - rhel7cis_rule_2_1_4
   tags:
       - level1
       - scored
@@ -135,7 +161,9 @@
 - name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-dgram"
   command: chkconfig echo-dgram off
   notify: restart xinetd
-  when: echo_dgram_service.stat.exists
+  when:
+      - echo_dgram_service.skipped is not defined and echo_dgram_service.stat.exists
+      - rhel7cis_rule_2_1_4
   tags:
       - level1
       - scored
@@ -146,6 +174,8 @@
   stat:
       path: /etc/xinetd.d/echo-stream
   register: echo_stream_service
+  when:
+      - rhel7cis_rule_2_1_4
   tags:
       - level1
       - scored
@@ -155,7 +185,9 @@
 - name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
   command: chkconfig echo-stream off
   notify: restart xinetd
-  when: echo_stream_service.stat.exists
+  when:
+      - echo_stream_service.skipped is not defined and echo_stream_service.stat.exists
+      - rhel7cis_rule_2_1_4
   tags:
       - level1
       - scored
@@ -166,6 +198,8 @@
   stat:
       path: /etc/xinetd.d/time-dgram
   register: time_dgram_service
+  when:
+      - rhel7cis_rule_2_1_5
   tags:
       - level1
       - scored
@@ -175,7 +209,9 @@
 - name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
   command: chkconfig time-dgram off
   notify: restart xinetd
-  when: time_dgram_service.stat.exists
+  when:
+      - time_dgram_service.skipped is not defined and time_dgram_service.stat.exists
+      - rhel7cis_rule_2_1_5
   tags:
       - level1
       - scored
@@ -186,6 +222,8 @@
   stat:
       path: /etc/xinetd.d/time-stream
   register: time_stream_service
+  when:
+      - rhel7cis_rule_2_1_5
   tags:
       - level1
       - scored
@@ -195,7 +233,9 @@
 - name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
   command: chkconfig time-stream off
   notify: restart xinetd
-  when: time_stream_service.stat.exists
+  when:
+      - time_stream_service.skipped is not defined and time_stream_service.stat.exists
+      - rhel7cis_rule_2_1_5
   tags:
       - level1
       - scored
@@ -206,6 +246,8 @@
   stat:
       path: /etc/xinetd.d/tftp
   register: tftp_service
+  when:
+      - rhel7cis_rule_2_1_6
   tags:
       - level1
       - scored
@@ -215,7 +257,9 @@
 - name: "SCORED | 2.1.6 | PATCH | Ensure tftp server is not enabled"
   command: chkconfig tftp off
   notify: restart xinetd
-  when: tftp_service.stat.exists and rhel7cis_tftp_server == false
+  when:
+      - tftp_service.skipped is not defined and tftp_service.stat.exists and rhel7cis_tftp_server == false
+      - rhel7cis_rule_2_1_6
   tags:
       - level1
       - scored
@@ -227,8 +271,9 @@
       name: xinetd
       state: stopped
       enabled: no
-  when: 
-      - xinetd_service_status.stdout == "loaded" and not rhel7cis_xinetd_required
+  when:
+      - xinetd_service_status.skipped is not defined and xinetd_service_status.stdout == "loaded" and not rhel7cis_xinetd_required
+      - rhel7cis_rule_2_1_7
   tags:
       - level1
       - patch
@@ -239,6 +284,8 @@
   yum:
       name: "{{ rhel7cis_time_synchronization }}"
       state: present
+  when:
+      - rhel7cis_rule_2_2_1_1
   tags:
       - level1
       - patch
@@ -249,6 +296,8 @@
       name: "{{ rhel7cis_time_synchronization }}d"
       state: started
       enabled: yes
+  when:
+      - rhel7cis_rule_2_2_1_1
   tags:
       - level1
       - patch
@@ -259,7 +308,9 @@
       name: ntpd
       state: stopped
       enabled: no
-  when: rhel7cis_time_synchronization == "chrony" and ntpd_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_time_synchronization == "chrony" and ntpd_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_1_1
   tags:
       - level1
       - patch
@@ -271,7 +322,9 @@
       state: stopped
       enabled: no
   ignore_errors: yes
-  when: rhel7cis_time_synchronization == "ntp" and chronyd_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_time_synchronization == "ntp" and chronyd_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_1_1
   tags:
       - level1
       - patch
@@ -284,7 +337,9 @@
       owner: root
       group: root
       mode: 0644
-  when: rhel7cis_time_synchronization == "ntp"
+  when:
+      - rhel7cis_time_synchronization == "ntp"
+      - rhel7cis_rule_2_2_1_2
   tags:
       - level1
       - patch
@@ -295,7 +350,9 @@
       dest: /etc/sysconfig/ntpd
       regexp: "^(#)?OPTIONS"
       line: "OPTIONS=\"-u ntp:ntp\""
-  when: rhel7cis_time_synchronization == "ntp"
+  when:
+      - rhel7cis_time_synchronization == "ntp"
+      - rhel7cis_rule_2_2_1_2
   tags:
       - level1
       - patch
@@ -306,7 +363,9 @@
       dest: /usr/lib/systemd/system/ntpd.service
       regexp: "^(#)?ExecStart"
       line: "ExecStart=/usr/sbin/ntpd -u ntp:ntp $OPTIONS"
-  when: rhel7cis_time_synchronization == "ntp"
+  when:
+      - rhel7cis_time_synchronization == "ntp"
+      - rhel7cis_rule_2_2_1_2
   tags:
       - level1
       - patch
@@ -319,7 +378,9 @@
       owner: root
       group: root
       mode: 0644
-  when: rhel7cis_time_synchronization == "chrony"
+  when:
+      - rhel7cis_time_synchronization == "chrony"
+      - rhel7cis_rule_2_2_1_3
   tags:
       - level1
       - patch
@@ -332,7 +393,9 @@
       line: "OPTIONS=\"-u chrony\""
       state: present
       create: yes
-  when: rhel7cis_time_synchronization == "chrony"
+  when:
+      - rhel7cis_time_synchronization == "chrony"
+      - rhel7cis_rule_2_2_1_3
   tags:
       - level1
       - patch
@@ -342,10 +405,12 @@
   yum:
       name: "{{item}}"
       state: absent
-  when: not rhel7cis_xwindows_required
   with_items:
       - "@X Window System"
       - "xorg-x11*"
+  when:
+      - not rhel7cis_xwindows_required
+      - rhel7cis_rule_2_2_2
   tags:
       - level1
       - scored
@@ -358,7 +423,9 @@
       name: avahi-daemon
       state: stopped
       enabled: no
-  when: rhel7cis_avahi_server == false and avahi_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_avahi_server == false and avahi_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_3
   tags:
       - level1
       - scored
@@ -372,7 +439,9 @@
       name: cups
       state: stopped
       enabled: no
-  when: rhel7cis_cups_server == false and cups_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_cups_server == false and cups_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_4
   tags:
       - level1
       - scored
@@ -386,7 +455,9 @@
       name: dhcpd
       state: stopped
       enabled: no
-  when: rhel7cis_dhcp_server == false and dhcpd_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_dhcp_server == false and dhcpd_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_5
   tags:
       - level1
       - scored
@@ -400,7 +471,9 @@
       name: slapd
       state: stopped
       enabled: no
-  when: rhel7cis_ldap_server == false and slapd_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_ldap_server == false and slapd_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_6
   tags:
       - level1
       - scored
@@ -414,7 +487,9 @@
       name: nfs
       state: stopped
       enabled: no
-  when: rhel7cis_nfs_rpc_server == false and nfs_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_nfs_rpc_server == false and nfs_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_7
   tags:
       - level1
       - scored
@@ -429,7 +504,9 @@
       name: rpcbind
       state: stopped
       enabled: no
-  when: rhel7cis_nfs_rpc_server == false and rpcbind_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_nfs_rpc_server == false and rpcbind_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_7
   tags:
       - level1
       - scored
@@ -444,7 +521,9 @@
       name: named
       state: stopped
       enabled: no
-  when: rhel7cis_named_server == false and named_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_named_server == false and named_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_8
   tags:
       - level1
       - patch
@@ -455,7 +534,9 @@
       name: vsftpd
       state: stopped
       enabled: no
-  when: rhel7cis_vsftpd_server == false and vsftpd_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_vsftpd_server == false and vsftpd_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_9
   tags:
       - level1
       - patch
@@ -466,7 +547,9 @@
       name: httpd
       state: stopped
       enabled: no
-  when: rhel7cis_httpd_server == false and httpd_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_httpd_server == false and httpd_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_10
   tags:
       - level1
       - patch
@@ -477,7 +560,9 @@
       name: dovecot
       state: stopped
       enabled: no
-  when: rhel7cis_dovecot_server == false and dovecot_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_dovecot_server == false and dovecot_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_11
   tags:
       - level1
       - patch
@@ -488,7 +573,9 @@
       name: smb
       state: stopped
       enabled: no
-  when: rhel7cis_smb_server == false and smb_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_smb_server == false and smb_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_12
   tags:
       - level1
       - patch
@@ -499,7 +586,9 @@
       name: squid
       state: stopped
       enabled: no
-  when: rhel7cis_squid_server == false and squid_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_squid_server == false and squid_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_13
   tags:
       - level1
       - patch
@@ -510,7 +599,9 @@
       name: snmpd
       state: stopped
       enabled: no
-  when: rhel7cis_snmp_server == false and snmpd_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_snmp_server == false and snmpd_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_14
   tags:
       - level1
       - patch
@@ -521,7 +612,9 @@
       dest: /etc/postfix/main.cf
       regexp: "^(#)?inet_interfaces"
       line: "inet_interfaces = localhost"
-  when: rhel7cis_is_mail_server == false and postfix_installed.rc == 0
+  when:
+      - rhel7cis_is_mail_server == false and postfix_installed.rc == 0
+      - rhel7cis_rule_2_2_15
   tags:
       - level1
       - patch
@@ -532,7 +625,9 @@
       name: ypserv
       state: stopped
       enabled: no
-  when: rhel7cis_nis_server == false and ypserv_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_nis_server == false and ypserv_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_16
   tags:
       - level1
       - patch
@@ -543,7 +638,9 @@
       name: rsh.socket
       state: stopped
       enabled: no
-  when: rhel7cis_rsh_server == false and rsh_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_rsh_server == false and rsh_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_17
   tags:
       - level1
       - patch
@@ -554,7 +651,9 @@
       name: rlogin.socket
       state: stopped
       enabled: no
-  when: rhel7cis_rsh_server == false and rlogin_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_rsh_server == false and rlogin_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_17
   tags:
       - level1
       - patch
@@ -565,7 +664,9 @@
       name: rexec.socket
       state: stopped
       enabled: no
-  when: rhel7cis_rsh_server == false and rexec_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_rsh_server == false and rexec_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_17
   tags:
       - level1
       - patch
@@ -576,7 +677,9 @@
       name: telnet
       state: stopped
       enabled: no
-  when: rhel7cis_telnet_server == false and telnet_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_telnet_server == false and telnet_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_18
   tags:
       - level1
       - patch
@@ -587,7 +690,9 @@
       name: tftp
       state: stopped
       enabled: no
-  when: rhel7cis_tftp_server == false and tftp_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_tftp_server == false and tftp_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_19
   tags:
       - level1
       - scored
@@ -601,7 +706,9 @@
       name: rsyncd
       state: stopped
       enabled: no
-  when: rhel7cis_rsyncd_server == false and rsyncd_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_rsyncd_server == false and rsyncd_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_20
   tags:
       - level1
       - patch
@@ -612,7 +719,9 @@
       name: ntalk
       state: stopped
       enabled: no
-  when: rhel7cis_ntalk_server == false and ntalk_service_status.stdout == "loaded"
+  when:
+      - rhel7cis_ntalk_server == false and ntalk_service_status.stdout == "loaded"
+      - rhel7cis_rule_2_2_21
   tags:
       - level1
       - patch
@@ -622,7 +731,9 @@
   yum:
       name: ypbind
       state: absent
-  when: rhel7cis_ypbind_required == false
+  when:
+      - rhel7cis_ypbind_required == false
+      - rhel7cis_rule_2_3_1
   tags:
       - level1
       - patch
@@ -632,7 +743,9 @@
   yum:
       name: rsh
       state: absent
-  when: rhel7cis_rsh_required == false
+  when:
+      - rhel7cis_rsh_required == false
+      - rhel7cis_rule_2_3_2
   tags:
       - level1
       - patch
@@ -642,7 +755,9 @@
   yum:
       name: talk
       state: absent
-  when: rhel7cis_talk_required == false
+  when:
+      - rhel7cis_talk_required == false
+      - rhel7cis_rule_2_3_3
   tags:
       - level1
       - patch
@@ -652,7 +767,9 @@
   yum:
       name: telnet
       state: absent
-  when: rhel7cis_telnet_required == false
+  when:
+      - rhel7cis_telnet_required == false
+      - rhel7cis_rule_2_3_4
   tags:
       - level1
       - patch
@@ -662,7 +779,9 @@
   yum:
       name: openldap-clients
       state: absent
-  when: rhel7cis_openldap_clients_required == false
+  when:
+      - rhel7cis_openldap_clients_required == false
+      - rhel7cis_rule_2_3_5
   tags:
       - level1
       - patch

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -41,7 +41,7 @@
   command: chkconfig chargen-stream off
   notify: restart xinetd
   when:
-      - chargen_stream_service is not defined and chargen_stream_service.stat.exists
+      - chargen_stream_service.skipped is not defined and chargen_stream_service.stat.exists
       - rhel7cis_rule_2_1_1
   tags:
       - level1

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -1,7 +1,24 @@
 - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram"
-  stat:
-      path: /etc/xinetd.d/chargen-dgram
-  register: chargen_dgram_service
+  block:
+      - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram"
+        stat:
+            path: /etc/xinetd.d/chargen-dgram
+        register: chargen_dgram_service
+
+      - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram"
+        command: chkconfig chargen-dgram off
+        notify: restart xinetd
+        when: chargen_dgram_service.stat.exists
+
+      - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-stream"
+        stat:
+            path: /etc/xinetd.d/chargen-stream
+        register: chargen_stream_service
+
+      - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-stream"
+        command: chkconfig chargen-stream off
+        notify: restart xinetd
+        when: chargen_stream_service.stat.exists
   when:
       - rhel7cis_rule_2_1_1
   tags:
@@ -11,49 +28,27 @@
       - patch
       - rule_2.1.1
 
-- name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram"
-  command: chkconfig chargen-dgram off
-  notify: restart xinetd
-  when:
-      - chargen_dgram_service.skipped is not defined and chargen_dgram_service.stat.exists
-      - rhel7cis_rule_2_1_1
-  tags:
-      - level1
-      - scored
-      - services
-      - patch
-      - rule_2.1.1
+- name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-dgram,daytime-stream"
+  block:
+      - name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-dgram"
+        stat:
+            path: /etc/xinetd.d/daytime-dgram
+        register: daytime_dgram_service
 
-- name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-stream"
-  stat:
-      path: /etc/xinetd.d/chargen-stream
-  register: chargen_stream_service
-  when:
-      - rhel7cis_rule_2_1_1
-  tags:
-      - level1
-      - scored
-      - services
-      - patch
-      - rule_2.1.1
+      - name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-dgram"
+        command: chkconfig daytime-dgram off
+        notify: restart xinetd
+        when: daytime_dgram_service.stat.exists
 
-- name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-stream"
-  command: chkconfig chargen-stream off
-  notify: restart xinetd
-  when:
-      - chargen_stream_service.skipped is not defined and chargen_stream_service.stat.exists
-      - rhel7cis_rule_2_1_1
-  tags:
-      - level1
-      - scored
-      - services
-      - patch
-      - rule_2.1.1
+      - name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-stream"
+        stat:
+            path: /etc/xinetd.d/daytime-stream
+        register: daytime_stream_service
 
-- name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-dgram"
-  stat:
-      path: /etc/xinetd.d/daytime-dgram
-  register: daytime_dgram_service
+      - name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-stream"
+        command: chkconfig daytime-stream off
+        notify: restart xinetd
+        when: daytime_stream_service.stat.exists
   when:
       - rhel7cis_rule_2_1_2
   tags:
@@ -62,46 +57,27 @@
       - patch
       - rule_2.1.2
 
-- name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-dgram"
-  command: chkconfig daytime-dgram off
-  notify: restart xinetd
-  when:
-      - daytime_dgram_service.skipped is not defined and daytime_dgram_service.stat.exists
-      - rhel7cis_rule_2_1_2
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.2
+- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-dgram,discard-stream"
+  block:
+      - name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-dgram"
+        stat:
+            path: /etc/xinetd.d/discard-dgram
+        register: discard_dgram_service
 
-- name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-stream"
-  stat:
-      path: /etc/xinetd.d/daytime-stream
-  register: daytime_stream_service
-  when:
-      - rhel7cis_rule_2_1_2
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.2
+      - name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-dgram"
+        command: chkconfig discard-dgram off
+        notify: restart xinetd
+        when: discard_dgram_service.stat.exists
 
-- name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-stream"
-  command: chkconfig daytime-stream off
-  notify: restart xinetd
-  when:
-      - daytime_stream_service.skipped is not defined and daytime_stream_service.stat.exists
-      - rhel7cis_rule_2_1_2
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.2
+      - name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
+        stat:
+            path: /etc/xinetd.d/discard-stream
+        register: discard_stream_service
 
-- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-dgram"
-  stat:
-      path: /etc/xinetd.d/discard-dgram
-  register: discard_dgram_service
+      - name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
+        command: chkconfig discard-stream off
+        notify: restart xinetd
+        when: discard_stream_service.stat.exists
   when:
       - rhel7cis_rule_2_1_3
   tags:
@@ -110,46 +86,27 @@
       - patch
       - rule_2.1.3
 
-- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-dgram"
-  command: chkconfig discard-dgram off
-  notify: restart xinetd
-  when:
-      - discard_dgram_service.skipped is not defined and discard_dgram_service.stat.exists
-      - rhel7cis_rule_2_1_3
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.3
+- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-dgram,echo-stream"
+  block:
+      - name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-dgram"
+        stat:
+            path: /etc/xinetd.d/echo-dgram
+        register: echo_dgram_service
 
-- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
-  stat:
-      path: /etc/xinetd.d/discard-stream
-  register: discard_stream_service
-  when:
-      - rhel7cis_rule_2_1_3
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.3
+      - name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-dgram"
+        command: chkconfig echo-dgram off
+        notify: restart xinetd
+        when: echo_dgram_service.stat.exists
 
-- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
-  command: chkconfig discard-stream off
-  notify: restart xinetd
-  when:
-      - discard_stream_service.skipped is not defined and discard_stream_service.stat.exists
-      - rhel7cis_rule_2_1_3
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.3
+      - name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
+        stat:
+            path: /etc/xinetd.d/echo-stream
+        register: echo_stream_service
 
-- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-dgram"
-  stat:
-      path: /etc/xinetd.d/echo-dgram
-  register: echo_dgram_service
+      - name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
+        command: chkconfig echo-stream off
+        notify: restart xinetd
+        when: echo_stream_service.stat.exists
   when:
       - rhel7cis_rule_2_1_4
   tags:
@@ -158,83 +115,28 @@
       - patch
       - rule_2.1.4
 
-- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-dgram"
-  command: chkconfig echo-dgram off
-  notify: restart xinetd
-  when:
-      - echo_dgram_service.skipped is not defined and echo_dgram_service.stat.exists
-      - rhel7cis_rule_2_1_4
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.4
+- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram,time-stream"
+  block:
+      - name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
+        stat:
+            path: /etc/xinetd.d/time-dgram
+        register: time_dgram_service
 
-- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
-  stat:
-      path: /etc/xinetd.d/echo-stream
-  register: echo_stream_service
-  when:
-      - rhel7cis_rule_2_1_4
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.4
+      - name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
+        command: chkconfig time-dgram off
+        notify: restart xinetd
+        when: time_dgram_service.stat.exists
 
-- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
-  command: chkconfig echo-stream off
-  notify: restart xinetd
-  when:
-      - echo_stream_service.skipped is not defined and echo_stream_service.stat.exists
-      - rhel7cis_rule_2_1_4
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.4
+      - name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
+        stat:
+            path: /etc/xinetd.d/time-stream
+        register: time_stream_service
 
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
-  stat:
-      path: /etc/xinetd.d/time-dgram
-  register: time_dgram_service
+      - name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
+        command: chkconfig time-stream off
+        notify: restart xinetd
+        when: time_stream_service.stat.exists
   when:
-      - rhel7cis_rule_2_1_5
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.5
-
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
-  command: chkconfig time-dgram off
-  notify: restart xinetd
-  when:
-      - time_dgram_service.skipped is not defined and time_dgram_service.stat.exists
-      - rhel7cis_rule_2_1_5
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.5
-
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
-  stat:
-      path: /etc/xinetd.d/time-stream
-  register: time_stream_service
-  when:
-      - rhel7cis_rule_2_1_5
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.5
-
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
-  command: chkconfig time-stream off
-  notify: restart xinetd
-  when:
-      - time_stream_service.skipped is not defined and time_stream_service.stat.exists
       - rhel7cis_rule_2_1_5
   tags:
       - level1
@@ -243,22 +145,17 @@
       - rule_2.1.5
 
 - name: "SCORED | 2.1.6 | PATCH | Ensure tftp server is not enabled"
-  stat:
-      path: /etc/xinetd.d/tftp
-  register: tftp_service
-  when:
-      - rhel7cis_rule_2_1_6
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.1.6
+  block:
+      - name: "SCORED | 2.1.6 | PATCH | Ensure tftp server is not enabled"
+        stat:
+            path: /etc/xinetd.d/tftp
+        register: tftp_service
 
-- name: "SCORED | 2.1.6 | PATCH | Ensure tftp server is not enabled"
-  command: chkconfig tftp off
-  notify: restart xinetd
+      - name: "SCORED | 2.1.6 | PATCH | Ensure tftp server is not enabled"
+        command: chkconfig tftp off
+        notify: restart xinetd
+        when: tftp_service.stat.exists and rhel7cis_tftp_server == false
   when:
-      - tftp_service.skipped is not defined and tftp_service.stat.exists and rhel7cis_tftp_server == false
       - rhel7cis_rule_2_1_6
   tags:
       - level1
@@ -272,7 +169,7 @@
       state: stopped
       enabled: no
   when:
-      - xinetd_service_status.skipped is not defined and xinetd_service_status.stdout == "loaded" and not rhel7cis_xinetd_required
+      - xinetd_service_status.stdout == "loaded" and not rhel7cis_xinetd_required
       - rhel7cis_rule_2_1_7
   tags:
       - level1


### PR DESCRIPTION
ok, a little bit of thought required here.   

Some of the tasks are chained together through the use of registered vars.   So, for example, task 2.1.1 stats a file to a registered var, then the next task does something if that file exists.   The problem is that if we skip the first part of the checks, then the registered var doesn't exist as expected and the second part fails with a dict error:

```
TASK [RHEL7-CIS : SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-stream] *************************************************
fatal: [webserver]: FAILED! => {"failed": true, "msg": "The conditional check 'chargen_stream_service.stat.exists' failed. The error was: error while evaluating conditional (chargen_stream_service.stat.exists): 'dict object' has no attribute 'stat'\n\nThe error appears to have been in '/home/vagrant/documobi/roles/RHEL7-CIS/tasks/section2.yml': line 45, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-stream\"\n  ^ here\n"}
```

After some thoughts about the best way to handle this, I came up with checking if the previous task had been skipped or not:

```- name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram"
  command: chkconfig chargen-dgram off
  notify: restart xinetd
  when:
      - chargen_dgram_service.skipped is not defined and chargen_dgram_service.stat.exists
      - rhel7cis_rule_2_1_1
  tags:
      - level1
      - scored
      - services
      - patch
      - rule_2.1.1
```

If the previous task skipped then the registered var (chargen_dgram_service) looks like this:

```TASK [RHEL7-CIS : debug] *****************************************************************************************************************************
ok: [webserver] => {
    "chargen_dgram_service": {
        "changed": false, 
        "skip_reason": "Conditional result was False", 
        "skipped": true
    }
}
```

The tasks that this affects are:
```
      - chargen_dgram_service.skipped is not defined and chargen_dgram_service.stat.exists
      - chargen_stream_service.skipped is not defined and chargen_stream_service.stat.exists
      - daytime_dgram_service.skipped is not defined and daytime_dgram_service.stat.exists
      - daytime_stream_service.skipped is not defined and daytime_stream_service.stat.exists
      - discard_dgram_service.skipped is not defined and discard_dgram_service.stat.exists
      - discard_stream_service.skipped is not defined and discard_stream_service.stat.exists
      - echo_dgram_service.skipped is not defined and echo_dgram_service.stat.exists
      - echo_stream_service.skipped is not defined and echo_stream_service.stat.exists
      - time_dgram_service.skipped is not defined and time_dgram_service.stat.exists
      - time_stream_service.skipped is not defined and time_stream_service.stat.exists
      - tftp_service.skipped is not defined and tftp_service.stat.exists and rhel7cis_tftp_server == false
      - xinetd_service_status.skipped is not defined and xinetd_service_status.stdout == "loaded" and not rhel7cis_xinetd_required
```
