### PR TITLE
adding Molecule testing

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,49 @@
+---
+
+extends: default
+
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    level: warning
+    require-starting-space: false
+    min-spaces-from-content: 2
+  comments-indentation: disable
+  document-end: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    max-start: 0
+    max-end: 0
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: true
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length:
+    max: 500
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: false
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy: disable

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# Makefile for RHEL7-CIS
+.PHONY: help
+help:
+	@echo
+	@echo This Makefile is used to test this role. Typical use:
+	@echo
+	@echo	make test
+	@echo	make clean
+	@echo
+	@echo To use an isolated python from this directory: 
+	@echo
+	@echo	make venv
+	@echo	. bin/activate
+	@echo
+
+# virtualenv allows isolation of python libraries
+.PHONY: venv
+venv: bin/python
+
+bin/python:
+	## System's python 2.7 needs only 2 things:
+	# pip is the package manager for python
+	pip -V || sudo easy_install pip
+	# virtualenv allows isolation of python libraries
+	virtualenv --version || sudo easy_install virtualenv
+
+	# Now with those two we can isolate our test setup.
+	virtualenv --system-site-packages .
+	bin/pip install -r requirements.txt
+	virtualenv --relocatable .
+
+# cleanup virtualenv and molecule
+clean:
+	rm -rf .molecule bin lib include lib64
+	rm -f .Python pip-selfcheck.json
+	
+.PHONY: lint
+lint: bin/python
+	( . bin/activate && find . -name "*.yml" |grep -v .molecule |xargs yamllint )
+
+.PHONY: test
+test: bin/python
+	( . bin/activate && molecule test )

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,26 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+provisioner:
+vagrant:
+  raw_config_args:
+    - "vbguest.auto_update = false"
+    - "vm.synced_folder './', '/vagrant', disabled: true"
+    - "ssh.insert_key = false"
+  platforms:
+    - name: centos/7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 2
+  instances:
+    - name: RHEL7-CIS
+      ansible_groups:
+        - group1
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - role: RHEL7-CIS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+molecule
+yamllint


### PR DESCRIPTION
SInce there is more development in this repo nowadays and by multiple developers, I'd like to run some tests on this ansible role using the [Molecule](http://molecule.readthedocs.io/en/latest/index.html) framework. The setup needs virtualenv and pip present on the host, as well as Vagrant and VirtualBox.