### PR TITLE
added on/off vars to all section6 tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -212,7 +212,38 @@ rhel7cis_rule_5_4_3: true
 rhel7cis_rule_5_4_4: true
 
 # Section 6 rules
-#rhel7cis_rule_6_1_1: true
+rhel7cis_rule_6_1_1: true
+rhel7cis_rule_6_1_2: true
+rhel7cis_rule_6_1_3: true
+rhel7cis_rule_6_1_4: true
+rhel7cis_rule_6_1_5: true
+rhel7cis_rule_6_1_6: true
+rhel7cis_rule_6_1_7: true
+rhel7cis_rule_6_1_8: true
+rhel7cis_rule_6_1_9: true
+rhel7cis_rule_6_1_10: true
+rhel7cis_rule_6_1_11: true
+rhel7cis_rule_6_1_12: true
+rhel7cis_rule_6_1_13: true
+rhel7cis_rule_6_1_14: true
+rhel7cis_rule_6_2_1: true
+rhel7cis_rule_6_2_2: true
+rhel7cis_rule_6_2_3: true
+rhel7cis_rule_6_2_4: true
+rhel7cis_rule_6_2_5: true
+rhel7cis_rule_6_2_6: true
+rhel7cis_rule_6_2_7: true
+rhel7cis_rule_6_2_8: true
+rhel7cis_rule_6_2_9: true
+rhel7cis_rule_6_2_10: true
+rhel7cis_rule_6_2_11: true
+rhel7cis_rule_6_2_12: true
+rhel7cis_rule_6_2_14: true
+rhel7cis_rule_6_2_15: true
+rhel7cis_rule_6_2_16: true
+rhel7cis_rule_6_2_17: true
+rhel7cis_rule_6_2_18: true
+rhel7cis_rule_6_2_19: true
 
 # Service configuration booleans set true to keep service
 rhel7cis_avahi_server: false

--- a/tasks/section6.yml
+++ b/tasks/section6.yml
@@ -1,6 +1,8 @@
 - name: "NOTSCORED | 6.1.1 | PATCH | Audit system file permissions"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_1_1
   tags:
       - level2
       - patch
@@ -13,6 +15,8 @@
       owner: root
       group: root
       mode: 0644
+  when:
+      - rhel7cis_rule_6_1_2
   tags:
       - level1
       - level2
@@ -25,6 +29,8 @@
       owner: root
       group: root
       mode: 0000
+  when:
+      - rhel7cis_rule_6_1_3
   tags:
       - level1
       - level2
@@ -37,6 +43,8 @@
       owner: root
       group: root
       mode: 0644
+  when:
+      - rhel7cis_rule_6_1_4
   tags:
       - level1
       - level2
@@ -49,6 +57,8 @@
       owner: root
       group: root
       mode: 0000
+  when:
+      - rhel7cis_rule_6_1_5
   tags:
       - level1
       - level2
@@ -61,6 +71,8 @@
       owner: root
       group: root
       mode: 0600
+  when:
+      - rhel7cis_rule_6_1_6
   tags:
       - level1
       - level2
@@ -73,6 +85,8 @@
       owner: root
       group: root
       mode: 0000
+  when:
+      - rhel7cis_rule_6_1_7
   tags:
       - level1
       - level2
@@ -85,6 +99,8 @@
       owner: root
       group: root
       mode: 0600
+  when:
+      - rhel7cis_rule_6_1_8
   tags:
       - level1
       - level2
@@ -97,6 +113,8 @@
       owner: root
       group: root
       mode: 0600
+  when:
+      - rhel7cis_rule_6_1_9
   tags:
       - level1
       - level2
@@ -106,6 +124,8 @@
 - name: "SCORED | 6.1.10 | PATCH | Ensure no world writable files exist"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_1_10
   tags:
       - level1
       - level2
@@ -116,6 +136,8 @@
 - name: "SCORED | 6.1.11 | PATCH | Ensure no unowned files or directories exist"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_1_11
   tags:
       - level1
       - level2
@@ -126,6 +148,8 @@
 - name: "SCORED | 6.1.12 | PATCH | Ensure no ungrouped files or directories exist"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_1_12
   tags:
       - level1
       - level2
@@ -136,6 +160,8 @@
 - name: "NOTSCORED | 6.1.13 | PATCH | Audit SUID executables"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_1_13
   tags:
       - level1
       - level2
@@ -146,6 +172,8 @@
 - name: "NOTSCORED | 6.1.14 | PATCH | Audit SGID executables"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_1_14
   tags:
       - level1
       - level2
@@ -158,7 +186,9 @@
   changed_when: no
   failed_when: no
   with_items: "{{ empty_password_accounts.stdout_lines }}"
-  when: empty_password_accounts.rc
+  when:
+      - empty_password_accounts.rc
+      - rhel7cis_rule_6_2_1
   tags:
       - level1
       - level2
@@ -169,6 +199,8 @@
   command: sed -i '/^+/ d' /etc/passwd
   changed_when: no
   failed_when: no
+  when:
+      - rhel7cis_rule_6_2_2
   tags:
       - level1
       - level2
@@ -179,6 +211,8 @@
   command: sed -i '/^+/ d' /etc/shadow
   changed_when: no
   failed_when: no
+  when:
+      - rhel7cis_rule_6_2_3
   tags:
       - level1
       - level2
@@ -189,6 +223,8 @@
   command: sed -i '/^+/ d' /etc/group
   changed_when: no
   failed_when: no
+  when:
+      - rhel7cis_rule_6_2_4
   tags:
       - level1
       - level2
@@ -200,7 +236,9 @@
   changed_when: no
   failed_when: no
   with_items: "{{ uid_zero_accounts_except_root.stdout_lines }}"
-  when: uid_zero_accounts_except_root.rc
+  when:
+      - uid_zero_accounts_except_root.rc
+      - rhel7cis_rule_6_2_5
   tags:
       - level1
       - level2
@@ -210,6 +248,8 @@
 - name: "SCORED | 6.2.6 | PATCH | Ensure root PATH Integrity"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_2_6
   tags:
       - level1
       - level2
@@ -220,6 +260,8 @@
 - name: "SCORED | 6.2.7 | PATCH | Ensure all users' home directories exist"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_2_7
   tags:
       - level1
       - level2
@@ -230,6 +272,8 @@
 - name: "SCORED | 6.2.8 | PATCH | Ensure users' home directories permissions are 750 or more restrictive"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_2_8
   tags:
       - level1
       - level2
@@ -240,6 +284,8 @@
 - name: "SCORED | 6.2.9 | PATCH | Ensure users own their home directories"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_2_9
   tags:
       - level1
       - level2
@@ -250,6 +296,8 @@
 - name: "SCORED | 6.2.10 | PATCH | Ensure users' dot files are not group or world writable"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_2_10
   tags:
       - level1
       - level2
@@ -262,6 +310,8 @@
       state: absent
       dest: "~{{ item }}/.forward"
   with_items: "{{ users.stdout_lines }}"
+  when:
+      - rhel7cis_rule_6_2_11
   tags:
       - level1
       - level2
@@ -273,6 +323,8 @@
       state: absent
       dest: "~{{ item }}/.netrc"
   with_items: "{{ users.stdout_lines }}"
+  when:
+      - rhel7cis_rule_6_2_12
   tags:
       - level1
       - level2
@@ -295,6 +347,8 @@
       state: absent
       dest: "~{{ item }}/.rhosts"
   with_items: "{{ users.stdout_lines }}"
+  when:
+      - rhel7cis_rule_6_2_14
   tags:
       - level1
       - level2
@@ -304,6 +358,8 @@
 - name: "SCORED | 6.2.15 | PATCH | Ensure all groups in /etc/passwd exist in /etc/group"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_2_15
   tags:
       - level1
       - level2
@@ -314,6 +370,8 @@
 - name: "SCORED | 6.2.16 | PATCH | Ensure no duplicate UIDs exist"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_2_16
   tags:
       - level1
       - level2
@@ -324,6 +382,8 @@
 - name: "SCORED | 6.2.17 | PATCH | Ensure no duplicate GIDs exist"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_2_17
   tags:
       - level1
       - level2
@@ -334,6 +394,8 @@
 - name: "SCORED | 6.2.18 | PATCH | Ensure no duplicate user names exist"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_2_18
   tags:
       - level1
       - level2
@@ -344,6 +406,8 @@
 - name: "SCORED | 6.2.19 | PATCH | Ensure no duplicate group names exist"
   command: /bin/true
   changed_when: no
+  when:
+      - rhel7cis_rule_6_2_19
   tags:
       - level1
       - level2


### PR DESCRIPTION
Added a when: clause to each section6 task to enable on/off control at a task level. Variables are of the form rhel7cis_rule_6_1_4: true and have their defaults and definition in defaults/main.yml (also updated by this change).

This PR relates to issue #26, and allows for more granular control over which tasks do and do not run.

**Note**, the main README has not been updated with a section on how to use task vars.  Not sure if this is required or not, or if I'm the best person to do that.