### PR TITLE
Update .gitignore - allow templates/etc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ tests/*.retry
 .Python
 .molecule/
 bin/
-etc/
+/etc/
 include/
 lib/
 pip-selfcheck.json


### PR DESCRIPTION
Without leading slash, etc/ matches templates/etc/, preventing commits which change those templates.