### PR TITLE
Use vars to control time sync server options for ntp/chrony.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -331,6 +331,9 @@ rhel7cis_time_synchronization_servers:
     - 2.pool.ntp.org
     - 3.pool.ntp.org
 
+rhel7cis_chrony_server_options: "minpoll 8"
+rhel7cis_ntp_server_options: "iburst"
+
 # 3.4.2 | PATCH | Ensure /etc/hosts.allow is configured
 rhel7cis_host_allow:
     - "10.0.0.0/255.0.0.0"

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -18,7 +18,7 @@
 # better to use IP numbers than host names.
 
 {% for server in rhel7cis_time_synchronization_servers -%}
-server {{ server }} minpoll 8
+server {{ server }} {{ rhel7cis_chrony_server_options }}
 {% endfor %}
 
 # Look here for the admin password needed for chronyc.  The initial

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -21,7 +21,7 @@ restrict ::1
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
 {% for server in rhel7cis_time_synchronization_servers -%}
-server {{ server }} iburst
+server {{ server }} {{ rhel7cis_ntp_server_options }}
 {% endfor %}
 
 #broadcast 192.168.1.255 autokey        # broadcast server


### PR DESCRIPTION
The settings for servers in the ntp.conf.j2 and chrony.conf.j2 templates
were previously hardcoded (to "iburst" and "minpoll 8", respectively),
but the user may wish to customise these.

This commit adds two new variables:
- rhel7cis_ntp_server_options
- rhel7cis_chrony_server_options

The default values are the same as the previously hardcoded values, so
there will be no change from the user side unless they override the
vars.