### PR TITLE
Remove 'weekly' from AIDE cron job comment.

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -578,7 +578,7 @@
 
 - name: "SCORED | 1.3.2 | PATCH | Ensure filesystem integrity is regularly checked"
   cron:
-      name: Run AIDE integrity check weekly
+      name: Run AIDE integrity check
       cron_file: "{{ rhel7cis_aide_cron['cron_file'] }}"
       user: "{{ rhel7cis_aide_cron['cron_user'] }}"
       minute: "{{ rhel7cis_aide_cron['aide_minute'] | default('0') }}"


### PR DESCRIPTION
The task is scheduled to run daily by default, and the actual schedule
is controllable by user variables, so let's not specify a schedule in
the comment.

Fixes issue #96 https://github.com/MindPointGroup/RHEL7-CIS/issues/96