### PR TITLE
🚨 Ansible-lint 3.4.23 warning ANSIBLE0006

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -53,153 +53,206 @@
   register: xinetd_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for ntpd service"
   shell: "systemctl show ntpd | grep LoadState | cut -d = -f 2"
   register: ntpd_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
+
 
 - name: "PRELIM | Check for chronyd service"
   shell: "systemctl show chronyd | grep LoadState | cut -d = -f 2"
   register: chronyd_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for avahi-daemon service"
   shell: "systemctl show avahi-daemon | grep LoadState | cut -d = -f 2"
   register: avahi_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for cups service"
   shell: "systemctl show cups | grep LoadState | cut -d = -f 2"
   register: cups_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for dhcpd service"
   shell: "systemctl show dhcpd | grep LoadState | cut -d = -f 2"
   register: dhcpd_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for slapd service"
   shell: "systemctl show slapd | grep LoadState | cut -d = -f 2"
   register: slapd_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for nfs service"
   shell: "systemctl show nfs | grep LoadState | cut -d = -f 2"
   register: nfs_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for rpcbind service"
   shell: "systemctl show rpcbind | grep LoadState | cut -d = -f 2"
   register: rpcbind_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for named service"
   shell: "systemctl show named | grep LoadState | cut -d = -f 2"
   register: named_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for vsftpd service"
   shell: "systemctl show vsftpd | grep LoadState | cut -d = -f 2"
   register: vsftpd_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for httpd service"
   shell: "systemctl show httpd | grep LoadState | cut -d = -f 2"
   register: httpd_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for dovecot service"
   shell: "systemctl show dovecot | grep LoadState | cut -d = -f 2"
   register: dovecot_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for smb service"
   shell: "systemctl show smb | grep LoadState | cut -d = -f 2"
   register: smb_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for squid service"
   shell: "systemctl show squid | grep LoadState | cut -d = -f 2"
   register: squid_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for snmpd service"
   shell: "systemctl show snmpd | grep LoadState | cut -d = -f 2"
   register: snmpd_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for ypserv service"
   shell: "systemctl show ypserv | grep LoadState | cut -d = -f 2"
   register: ypserv_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for rsh.socket service"
   shell: "systemctl show rsh.socket | grep LoadState | cut -d = -f 2"
   register: rsh_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for rlogin.socket service"
   shell: "systemctl show rlogin.socket | grep LoadState | cut -d = -f 2"
   register: rlogin_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for rexec.socket service"
   shell: "systemctl show rexec.socket | grep LoadState | cut -d = -f 2"
   register: rexec_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for telnet service"
   shell: "systemctl show telnet | grep LoadState | cut -d = -f 2"
   register: telnet_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for tftp service"
   shell: "systemctl show tftp | grep LoadState | cut -d = -f 2"
   register: tftp_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for rsyncd service"
   shell: "systemctl show rsyncd | grep LoadState | cut -d = -f 2"
   register: rsyncd_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for ntalk service"
   shell: "systemctl show ntalk | grep LoadState | cut -d = -f 2"
   register: ntalk_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for autofs service"
   shell: "systemctl show autofs | grep LoadState | cut -d = -f 2"
   register: autofs_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006
 
 - name: "PRELIM | Check for rhnsd service"
   shell: "systemctl show rhnsd | grep LoadState | cut -d = -f 2"
   register: rhnsd_service_status
   changed_when: no
   check_mode: no
+  tags:
+    - skip_ansible_lint #  ANSIBLE0006

--- a/tasks/section6.yml
+++ b/tasks/section6.yml
@@ -206,6 +206,7 @@
       - level2
       - patch
       - rule_6.2.2
+      - skip_ansible_lint #  ANSIBLE0006
 
 - name: "SCORED | 6.2.3 | PATCH | Ensure no legacy '+' entries exist in /etc/shadow"
   command: sed -i '/^+/ d' /etc/shadow
@@ -218,6 +219,7 @@
       - level2
       - patch
       - rule_6.2.3
+      - skip_ansible_lint #  ANSIBLE0006
 
 - name: "SCORED | 6.2.4 | PATCH | Ensure no legacy '+' entries exist in /etc/group"
   command: sed -i '/^+/ d' /etc/group
@@ -230,6 +232,7 @@
       - level2
       - patch
       - rule_6.2.4
+      - skip_ansible_lint #  ANSIBLE0006
 
 - name: "SCORED | 6.2.5 | PATCH | Ensure root is the only UID 0 account"
   command: passwd -l {{ item }}


### PR DESCRIPTION
### Ansible-linting

I encountered a number of new warnings looking into this role again. This time using the role in a newer setup:

```ini
demo:RHEL7-CIS bas$ ansible-lint playbook.yml
[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:51
Task/Handler: PRELIM | Check for xinetd service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:57
Task/Handler: PRELIM | Check for ntpd service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:63
Task/Handler: PRELIM | Check for chronyd service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:69
Task/Handler: PRELIM | Check for avahi-daemon service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:75
Task/Handler: PRELIM | Check for cups service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:81
Task/Handler: PRELIM | Check for dhcpd service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:87
Task/Handler: PRELIM | Check for slapd service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:93
Task/Handler: PRELIM | Check for nfs service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:99
Task/Handler: PRELIM | Check for rpcbind service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:105
Task/Handler: PRELIM | Check for named service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:111
Task/Handler: PRELIM | Check for vsftpd service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:117
Task/Handler: PRELIM | Check for httpd service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:123
Task/Handler: PRELIM | Check for dovecot service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:129
Task/Handler: PRELIM | Check for smb service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:135
Task/Handler: PRELIM | Check for squid service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:141
Task/Handler: PRELIM | Check for snmpd service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:147
Task/Handler: PRELIM | Check for ypserv service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:153
Task/Handler: PRELIM | Check for rsh.socket service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:159
Task/Handler: PRELIM | Check for rlogin.socket service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:165
Task/Handler: PRELIM | Check for rexec.socket service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:171
Task/Handler: PRELIM | Check for telnet service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:177
Task/Handler: PRELIM | Check for tftp service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:183
Task/Handler: PRELIM | Check for rsyncd service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:189
Task/Handler: PRELIM | Check for ntalk service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:195
Task/Handler: PRELIM | Check for autofs service

[ANSIBLE0006] systemctl used in place of systemd module
/Users/bas/code/ansible/RHEL7-CIS/tasks/prelim.yml:201
Task/Handler: PRELIM | Check for rhnsd service

[ANSIBLE0006] sed used in place of template or lineinfile module
/Users/bas/code/ansible/RHEL7-CIS/tasks/section6.yml:198
Task/Handler: SCORED | 6.2.2 | PATCH | Ensure no legacy '+' entries exist in /etc/passwd

[ANSIBLE0006] sed used in place of template or lineinfile module
/Users/bas/code/ansible/RHEL7-CIS/tasks/section6.yml:210
Task/Handler: SCORED | 6.2.3 | PATCH | Ensure no legacy '+' entries exist in /etc/shadow

[ANSIBLE0006] sed used in place of template or lineinfile module
/Users/bas/code/ansible/RHEL7-CIS/tasks/section6.yml:222
Task/Handler: SCORED | 6.2.4 | PATCH | Ensure no legacy '+' entries exist in /etc/group
```