### PR TITLE
Enable Amazon Linux 2

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
       msg: "This role can only be run against RHEL 7. {{ ansible_distribution }} {{ ansible_distribution_major_version }} is not supported."
   when:
       - ansible_os_family == 'RedHat'
-      - ansible_distribution_major_version | version_compare('7', '!=')
+      - (ansible_distribution_major_version | version_compare('7', '!=')) and  (ansible_distribution_major_version | version_compare('NA', '!='))
   tags:
       - always
 


### PR DESCRIPTION
Following change enables the role to be used by Amazon Linux 2