### PR TITLE
Removing deprecated yum loop

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -3,13 +3,12 @@
   pre_tasks:
     - name: install packages for testing under docker
       yum:
-        name: "{{ item }}"
+        name:
+          - selinux-policy
+          - libselinux-python
+          - openssh-server
+          - which
         state: present
-      with_items:
-        - selinux-policy
-        - libselinux-python
-        - openssh-server
-        - which
-
+       
   roles:
     - role: RHEL7-CIS


### PR DESCRIPTION
Removing yum loop to get rid of this warning:

[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: "{{item}}"`, please use `name: ['@X Window System',
'xorg-x11*']` and remove the loop. This feature will be removed in version
2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.