### PR TITLE
Set IPv6 regardless of IPv6 state (3.3.1 & 3.3.2)

### DIFF
--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -208,7 +208,6 @@
   notify:
       - sysctl flush ipv6 route table
   when:
-      - rhel7cis_ipv6_required == true
       - rhel7cis_rule_3_3_1
   tags:
       - level1
@@ -230,7 +229,6 @@
   notify:
       - sysctl flush ipv6 route table
   when:
-      - rhel7cis_ipv6_required == true
       - rhel7cis_rule_3_3_2
   tags:
       - level1


### PR DESCRIPTION
fixes #132 

Removed rhel7cis_ipv6_required == true from 3.3.1 and 3.3.2 so IPv6 configuration is set even if the user sets IPv6 to disabled via rhel7cis_ipv6_required == false