### PR TITLE
add variable for sudo log file for 4.1.16

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -360,6 +360,8 @@ rhel7cis_auditd:
 
 rhel7cis_logrotate: "daily"
 
+rhel7cis_sudolog: /var/log/secure
+
 ## Section5 vars
 
 rhel7cis_sshd:

--- a/templates/audit/rhel7cis_rule_4_1_16.rules.j2
+++ b/templates/audit/rhel7cis_rule_4_1_16.rules.j2
@@ -1,1 +1,1 @@
--w /var/log/sudo.log -p wa -k actions
+-w {{ rhel7cis_sudolog }} -p wa -k actions


### PR DESCRIPTION
Fixes #137 
Changes the 4.1.16 audit rule to point to the correct path for RHEL.