### PR TITLE
Add variables for pwquality | 5.3.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -378,6 +378,14 @@ rhel7cis_pass:
     max_days: 90
     min_days: 7
     warn_age: 7
+
+rhel7cis_pwquality:
+  minlen: '14'
+  dcredit: '-1'
+  ucredit: '-1'
+  ocredit: '-1'
+  lcredit: '-1'
+
 # Syslog system
 rhel7cis_syslog: rsyslog
 #rhel7cis_syslog: syslog-ng

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -380,11 +380,11 @@ rhel7cis_pass:
     warn_age: 7
 
 rhel7cis_pwquality:
-  minlen: '14'
-  dcredit: '-1'
-  ucredit: '-1'
-  ocredit: '-1'
-  lcredit: '-1'
+    minlen: '14'
+    dcredit: '-1'
+    ucredit: '-1'
+    ocredit: '-1'
+    lcredit: '-1'
 
 # Syslog system
 rhel7cis_syslog: rsyslog

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -423,7 +423,7 @@
       dest: /etc/security/pwquality.conf
       regexp: '^{{ item.key }}'
       line: '{{ item.key }} = {{ item.value }}'
-  loop: "{{ rhel7cis_pwquality | dict2items }}"
+  with_dict: "{{ rhel7cis_pwquality }}"
   when:
       - rhel7cis_rule_5_3_1|bool
   tags:

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -421,7 +421,7 @@
   lineinfile:
       state: present
       dest: /etc/security/pwquality.conf
-      regexp: '^{{ item.key }}'
+      regexp: ^{{ item.key }}[ =]
       line: '{{ item.key }} = {{ item.value }}'
   with_dict: "{{ rhel7cis_pwquality }}"
   when:

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -418,17 +418,16 @@
       - rule_5.2.16
 
 - name: "SCORED | 5.3.1 | PATCH | Ensure password creation requirements are configured"
-  lineinfile:
+  ini_file:
       state: present
-      dest: /etc/security/pwquality.conf
-      regexp: '^{{ item.key }}'
-      line: '{{ item.key }} = {{ item.value }}'
-  with_items:
-      - { key: 'minlen', value: '14' }
-      - { key: 'dcredit', value: '-1' }
-      - { key: 'ucredit', value: '-1' }
-      - { key: 'ocredit', value: '-1' }
-      - { key: 'lcredit', value: '-1' }
+      path: /etc/security/pwquality.conf
+      owner: root
+      group: root
+      mode: '0644'
+      section: null
+      option: "{{ item.key }}"
+      value: "{{ item.value }}"
+  loop: "{{ rhel7cis_pwquality | dict2items }}"
   when:
       - rhel7cis_rule_5_3_1|bool
   tags:

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -418,15 +418,11 @@
       - rule_5.2.16
 
 - name: "SCORED | 5.3.1 | PATCH | Ensure password creation requirements are configured"
-  ini_file:
+  lineinfile:
       state: present
-      path: /etc/security/pwquality.conf
-      owner: root
-      group: root
-      mode: '0644'
-      section: null
-      option: "{{ item.key }}"
-      value: "{{ item.value }}"
+      dest: /etc/security/pwquality.conf
+      regexp: '^{{ item.key }}'
+      line: '{{ item.key }} = {{ item.value }}'
   loop: "{{ rhel7cis_pwquality | dict2items }}"
   when:
       - rhel7cis_rule_5_3_1|bool


### PR DESCRIPTION
The CIS benchmark provides an example configuration for /etc/security/pwquality.conf.
This PR replaces the configuration in the task with variables which can be overridden.

Additionally, I've replaced the use of lineinfile with ini_file, which I believe is suitable and a little simpler.