### PR TITLE
Clean up string conversion warnings

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,7 +5,7 @@
   become: yes
   sysctl:
       name: net.ipv4.route.flush
-      value: 1
+      value: '1'
       sysctl_set: yes
   when: ansible_virtualization_type != "docker"
 
@@ -13,7 +13,7 @@
   become: yes
   sysctl:
       name: net.ipv6.route.flush
-      value: 1
+      value: '1'
       sysctl_set: yes
   when: ansible_virtualization_type != "docker"
 

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -25,8 +25,8 @@
       reload: yes
       ignoreerrors: yes
   with_items:
-      - { name: net.ipv4.conf.all.send_redirects, value: 0 }
-      - { name: net.ipv4.conf.default.send_redirects, value: 0 }
+      - { name: net.ipv4.conf.all.send_redirects, value: '0' }
+      - { name: net.ipv4.conf.default.send_redirects, value: '0' }
   notify:
       - sysctl flush ipv4 route table
   when:
@@ -47,8 +47,8 @@
       reload: yes
       ignoreerrors: yes
   with_items:
-      - { name: net.ipv4.conf.all.accept_source_route, value: 0 }
-      - { name: net.ipv4.conf.default.accept_source_route, value: 0 }
+      - { name: net.ipv4.conf.all.accept_source_route, value: '0' }
+      - { name: net.ipv4.conf.default.accept_source_route, value: '0' }
   notify:
       - sysctl flush ipv4 route table
   when:
@@ -68,8 +68,8 @@
       reload: yes
       ignoreerrors: yes
   with_items:
-      - { name: net.ipv4.conf.all.accept_redirects, value: 0 }
-      - { name: net.ipv4.conf.default.accept_redirects, value: 0 }
+      - { name: net.ipv4.conf.all.accept_redirects, value: '0' }
+      - { name: net.ipv4.conf.default.accept_redirects, value: '0' }
   notify:
       - sysctl flush ipv4 route table
   when:
@@ -89,8 +89,8 @@
       reload: yes
       ignoreerrors: yes
   with_items:
-      - { name: net.ipv4.conf.all.secure_redirects, value: 0 }
-      - { name: net.ipv4.conf.default.secure_redirects, value: 0 }
+      - { name: net.ipv4.conf.all.secure_redirects, value: '0' }
+      - { name: net.ipv4.conf.default.secure_redirects, value: '0' }
   notify:
       - sysctl flush ipv4 route table
   when:
@@ -110,8 +110,8 @@
       reload: yes
       ignoreerrors: yes
   with_items:
-      - { name: net.ipv4.conf.all.log_martians, value: 1 }
-      - { name: net.ipv4.conf.default.log_martians, value: 1 }
+      - { name: net.ipv4.conf.all.log_martians, value: '1' }
+      - { name: net.ipv4.conf.default.log_martians, value: '1' }
   notify:
       - sysctl flush ipv4 route table
   when:
@@ -165,8 +165,8 @@
       reload: yes
       ignoreerrors: yes
   with_items:
-      - { name: net.ipv4.conf.all.rp_filter, value: 1 }
-      - { name: net.ipv4.conf.default.rp_filter, value: 1 }
+      - { name: net.ipv4.conf.all.rp_filter, value: '1' }
+      - { name: net.ipv4.conf.default.rp_filter, value: '1' }
   notify:
       - sysctl flush ipv4 route table
   when:
@@ -203,8 +203,8 @@
       reload: yes
       ignoreerrors: yes
   with_items:
-      - { name: net.ipv6.conf.all.accept_ra, value: 0 }
-      - { name: net.ipv6.conf.default.accept_ra, value: 0 }
+      - { name: net.ipv6.conf.all.accept_ra, value: '0' }
+      - { name: net.ipv6.conf.default.accept_ra, value: '0' }
   notify:
       - sysctl flush ipv6 route table
   when:
@@ -225,8 +225,8 @@
       reload: yes
       ignoreerrors: yes
   with_items:
-      - { name: net.ipv6.conf.all.accept_redirects, value: 0 }
-      - { name: net.ipv6.conf.default.accept_redirects, value: 0 }
+      - { name: net.ipv6.conf.all.accept_redirects, value: '0' }
+      - { name: net.ipv6.conf.default.accept_redirects, value: '0' }
   notify:
       - sysctl flush ipv6 route table
   when:

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -180,7 +180,7 @@
 - name: "SCORED | 3.2.8 | PATCH | Ensure TCP SYN Cookies is enabled"
   sysctl:
       name: net.ipv4.tcp_syncookies
-      value: 1
+      value: '1'
       state: present
       reload: yes
       ignoreerrors: yes


### PR DESCRIPTION
The sysctl module expects the value parameter to be a string.
Ansible will log a warning when converting ints:

```
TASK [RHEL7-CIS : SCORED | 3.2.8 | PATCH | Ensure TCP SYN Cookies is enabled] ******************************
[WARNING]: The value 1 (type int) in a string field was converted to u'1' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
```