### PR TITLE
Fix the 1.4.3 'when' condition

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -679,7 +679,7 @@
             line: 'ExecStart=-/bin/sh -c \"/usr/sbin/sulogin; /usr/bin/systemctl --fail --no-block default\"'
         when:
             - rhel7cis_rule_1_4_3|bool
-            - ansible_distribution_major_version == 7
+            - ansible_distribution_major_version is version_compare('7', '==')
         tags:
             - level1
             - level2
@@ -692,7 +692,7 @@
             line: 'ExecStart=-/bin/sh -c \"/usr/sbin/sulogin; /usr/bin/systemctl --fail --no-block default\"'
         when:
             - rhel7cis_rule_1_4_3|bool
-            - ansible_distribution_major_version == 7
+            - ansible_distribution_major_version is version_compare('7', '==')
         tags:
             - level1
             - level2


### PR DESCRIPTION
1.4.3 was always skipped because `ansible_distribution_major_version` was the string `'7'`, which in Python is different from the int `7`:

```
In [1]: '7' == 7
Out[1]: False
```

Fixed by casting `ansible_distribution_major_version` to int. This fix should also be backwards compatible if there happens to be previous versions of Ansible where `ansible_distribution_major_version` *is* actually an int.

Tested with Ansible 2.9.4 / Python 3.6.7.
