### PR TITLE
Fix possibility to disable 1.4.1

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -631,8 +631,8 @@
       group: root
       mode: 0600
   when:
-      - grub_cfg.stat.exists and grub_cfg.stat.islnk
       - rhel7cis_rule_1_4_1|bool
+      - grub_cfg.stat.exists and grub_cfg.stat.islnk
   tags:
       - level1
       - scored


### PR DESCRIPTION
Setting `rhel7cis_rule_1_4_1: false` causes the following error:

```
fatal: [172.105.84.27]: FAILED! =>
  msg: |-
    The conditional check 'grub_cfg.stat.exists and grub_cfg.stat.islnk' failed. The error was: error while evaluating conditional (grub_cfg.stat.exists and grub_cfg.stat.islnk): 'dict object' has no attribute 'stat'

    The error appears to be in '/Users/---/projects/RHEL7-CIS-TEST/t.yml': line 25, column 7, but may
    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:


        - name: "SCORED | 1.4.1 | PATCH | Ensure permissions on bootloader config are configured"
          ^ here
```

This is because `grub_cfg` is never defined when `rhel7cis_rule_1_4_1` is false, but it's requested in the `when:` check of the next task.

This PR fixes the issue by reordering the `when:` conditions so that `rhel7cis_rule_1_4_1` is checked *before* `grub_cfg`.

