### PR TITLE
gather users from /home and passwd

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tox
 molecule
 docker
 python-vagrant==0.5.15
+jmespath

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -3,9 +3,23 @@
 # List users in order to look files inside each home directory
 - name: "PRELIM | List users accounts"
   command: "awk -F: '{print $1}' /etc/passwd"
-  register: users
+  register: passwd
   changed_when: no
   check_mode: no
+
+- name: "PRELIM | List home directories"
+  find:
+      paths:
+          - /home
+      file_type: directory
+  register: homes
+
+- name: "PRELIM | List all users"
+  set_fact:
+      users: "{{ list_passwd | union(list_homes) | unique }}"
+  vars:
+      list_passwd: "{{ passwd | json_query('stdout_lines') }}"
+      list_homes: "{{ homes | json_query('files[*].path') | regex_replace('/home/', '') }}"
 
 - name: "PRELIM | Gather accounts with empty password fields"
   command: "awk -F: '($2 == \"\" ) {j++;print $1; } END {exit j}' /etc/shadow"

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -14,8 +14,8 @@
       patterns:
           - '.bash_profile'
       depth: 2
-      recurse: no
-      hidden: no
+      recurse: yes
+      hidden: yes
   register: homes
 
 - name: "PRELIM | Resolve home directories to usernames"

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -11,15 +11,27 @@
   find:
       paths:
           - /home
-      file_type: directory
+      patterns:
+          - '.bash_profile'
+      depth: 2
+      recurse: no
+      hidden: no
   register: homes
+
+- name: "PRELIM | Resolve home directories to usernames"
+  command: "id -un {{ item }}"
+  with_items: "{{ homes | json_query('files[*].path') | map('dirname') | map('basename') | list }}"
+  changed_when: no
+  check_mode: no
+  ignore_errors: yes
+  register: home_usernames
 
 - name: "PRELIM | List all users"
   set_fact:
       users: "{{ list_passwd | union(list_homes) | unique }}"
   vars:
       list_passwd: "{{ passwd | json_query('stdout_lines') }}"
-      list_homes: "{{ homes | json_query('files[*].path') | regex_replace('/home/', '') }}"
+      list_homes: "{{ home_usernames.results | json_query('[*].stdout') }}"
 
 - name: "PRELIM | Gather accounts with empty password fields"
   command: "awk -F: '($2 == \"\" ) {j++;print $1; } END {exit j}' /etc/shadow"

--- a/tasks/section6.yml
+++ b/tasks/section6.yml
@@ -312,7 +312,7 @@
   file:
       state: absent
       dest: "~{{ item }}/.forward"
-  with_items: "{{ users.stdout_lines }}"
+  with_items: "{{ users }}"
   when:
       - rhel7cis_rule_6_2_11|bool
   tags:
@@ -325,7 +325,7 @@
   file:
       state: absent
       dest: "~{{ item }}/.netrc"
-  with_items: "{{ users.stdout_lines }}"
+  with_items: "{{ users }}"
   when:
       - rhel7cis_rule_6_2_12|bool
   tags:
@@ -349,7 +349,7 @@
   file:
       state: absent
       dest: "~{{ item }}/.rhosts"
-  with_items: "{{ users.stdout_lines }}"
+  with_items: "{{ users }}"
   when:
       - rhel7cis_rule_6_2_14|bool
   tags:


### PR DESCRIPTION
fixes #150 

Creates the `users` fact by combining the output of the `passwd` command, and the names of the subdirectories of `/home`.

Will need to be rebased if merged after #151 