### PR TITLE
1.2.3 | listing gpg keys is not a change

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -521,7 +521,7 @@
       - patch
       - rule_1.2.2
 
-- name: "NOTSCORED | 1.2.3 | PATCH | Ensure GPG keys are configured"
+- name: "NOTSCORED | 1.2.3 | AUDIT | Ensure GPG keys are configured"
   command: gpg --quiet --with-fingerprint /etc/pki/rpm-gpg/RPM-GPG-KEY-{{ ansible_distribution|lower }}-release
   changed_when: no
   when:

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -523,6 +523,7 @@
 
 - name: "NOTSCORED | 1.2.3 | PATCH | Ensure GPG keys are configured"
   command: gpg --quiet --with-fingerprint /etc/pki/rpm-gpg/RPM-GPG-KEY-{{ ansible_distribution|lower }}-release
+  changed_when: no
   when:
       - rhel7cis_rule_1_2_3|bool
       - ansible_distribution == "RedHat"


### PR DESCRIPTION
The `gpg` command in this task is just listing the keys in the RPM-GPG-KEY-... file, not making any changes.
The task will still fail if gpg returns a non-zero result.