### PR TITLE
add missing become: yes to restart sshd handler commands

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -65,11 +65,13 @@
   register: ssh_host_keys
 
 - name: check sshd configuration
+  become: yes
   command: '/usr/sbin/sshd -t'
   register: sshd_config
   changed_when: "sshd_config.rc != 0"
 
 - name: restart sshd - after config check
+  become: yes
   service:
       name: sshd
       state: restarted


### PR DESCRIPTION
When executing the role against one of our brand new machines using a deployment user I noticed that 2 become statements were missing.