### PR TITLE
Allow dependabot to keep python packages up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This change allows dependabot to check any python dependencies which this project uses on a weekly basis and submit pull requests with version bumps in order to keep packages up-to-date.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates

It looks like there's currently only one package that is being pinned and that package hasn't been updated since 2017, but if it were ever upgraded, dependabot would notify the maintainers with a pull request.

https://github.com/ansible-lockdown/RHEL7-CIS/blob/devel/requirements.txt#L6

