### PR TITLE
Add flag for allowing users to disable the RHEL7 O/S check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Requirements
 ------------
 
 You should carefully read through the tasks to make sure these changes will not break your systems before running this playbook.
-If you want to do a dry run without changing anything, set the below sections (rhel7cis_section1-6) to false. 
+If you want to do a dry run without changing anything, set the below sections (rhel7cis_section1-6) to false.
 
 Role Variables
 --------------
@@ -46,53 +46,56 @@ There are many role variables defined in defaults/main.yml. This list shows the 
 
 **rhel7cis_section5**: CIS - Access, Authentication and Authorization settings (Section 5) (Default: true)
 
-**rhel7cis_section6**: CIS - System Maintenance settings (Section 6) (Default: true)  
+**rhel7cis_section6**: CIS - System Maintenance settings (Section 6) (Default: true)
 
 ##### Disable all selinux functions
 `rhel7cis_selinux_disable: false`
+
+##### Disable check for RHEL7 O/S
+`rhel7cis_check_for_rhel7_os: false`
 
 ##### Service variables:
 ###### These control whether a server should or should not be allowed to continue to run these services
 
 ```
-rhel7cis_avahi_server: false  
-rhel7cis_cups_server: false  
-rhel7cis_dhcp_server: false  
-rhel7cis_ldap_server: false  
-rhel7cis_telnet_server: false  
-rhel7cis_nfs_server: false  
-rhel7cis_rpc_server: false  
-rhel7cis_ntalk_server: false  
-rhel7cis_rsyncd_server: false  
-rhel7cis_tftp_server: false  
-rhel7cis_rsh_server: false  
-rhel7cis_nis_server: false  
-rhel7cis_snmp_server: false  
-rhel7cis_squid_server: false  
-rhel7cis_smb_server: false  
-rhel7cis_dovecot_server: false  
-rhel7cis_httpd_server: false  
-rhel7cis_vsftpd_server: false  
-rhel7cis_named_server: false  
-rhel7cis_bind: false  
-rhel7cis_vsftpd: false  
-rhel7cis_httpd: false  
-rhel7cis_dovecot: false  
-rhel7cis_samba: false  
-rhel7cis_squid: false  
-rhel7cis_net_snmp: false  
-```  
+rhel7cis_avahi_server: false
+rhel7cis_cups_server: false
+rhel7cis_dhcp_server: false
+rhel7cis_ldap_server: false
+rhel7cis_telnet_server: false
+rhel7cis_nfs_server: false
+rhel7cis_rpc_server: false
+rhel7cis_ntalk_server: false
+rhel7cis_rsyncd_server: false
+rhel7cis_tftp_server: false
+rhel7cis_rsh_server: false
+rhel7cis_nis_server: false
+rhel7cis_snmp_server: false
+rhel7cis_squid_server: false
+rhel7cis_smb_server: false
+rhel7cis_dovecot_server: false
+rhel7cis_httpd_server: false
+rhel7cis_vsftpd_server: false
+rhel7cis_named_server: false
+rhel7cis_bind: false
+rhel7cis_vsftpd: false
+rhel7cis_httpd: false
+rhel7cis_dovecot: false
+rhel7cis_samba: false
+rhel7cis_squid: false
+rhel7cis_net_snmp: false
+```
 
 ##### Designate server as a Mail server
 `rhel7cis_is_mail_server: false`
 
 
 ##### System network parameters (host only OR host and router)
-`rhel7cis_is_router: false`  
+`rhel7cis_is_router: false`
 
 
 ##### IPv6 required
-`rhel7cis_ipv6_required: true`  
+`rhel7cis_ipv6_required: true`
 
 
 ##### AIDE
@@ -108,24 +111,24 @@ rhel7cis_aide_cron:
   aide_hour: 5
   aide_day: '*'
   aide_month: '*'
-  aide_weekday: '*'  
+  aide_weekday: '*'
 ```
 
 ##### SELinux policy
-`rhel7cis_selinux_pol: targeted` 
+`rhel7cis_selinux_pol: targeted`
 
 
 ##### Set to 'true' if X Windows is needed in your environment
-`rhel7cis_xwindows_required: no` 
+`rhel7cis_xwindows_required: no`
 
 
 ##### Client application requirements
 ```
-rhel7cis_openldap_clients_required: false 
-rhel7cis_telnet_required: false 
-rhel7cis_talk_required: false  
-rhel7cis_rsh_required: false 
-rhel7cis_ypbind_required: false 
+rhel7cis_openldap_clients_required: false
+rhel7cis_telnet_required: false
+rhel7cis_talk_required: false
+rhel7cis_rsh_required: false
+rhel7cis_ypbind_required: false
 ```
 
 ##### Time Synchronization
@@ -137,22 +140,22 @@ rhel7cis_time_synchronization_servers:
     - 0.pool.ntp.org
     - 1.pool.ntp.org
     - 2.pool.ntp.org
-    - 3.pool.ntp.org  
-```  
-  
+    - 3.pool.ntp.org
+```
+
 ##### 3.4.2 | PATCH | Ensure /etc/hosts.allow is configured
 ```
 rhel7cis_host_allow:
-  - "10.0.0.0/255.0.0.0"  
-  - "172.16.0.0/255.240.0.0"  
-  - "192.168.0.0/255.255.0.0"    
-```  
+  - "10.0.0.0/255.0.0.0"
+  - "172.16.0.0/255.240.0.0"
+  - "192.168.0.0/255.255.0.0"
+```
 
 ```
 rhel7cis_firewall: firewalld
 rhel7cis_firewall: iptables
-``` 
-  
+```
+
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,8 @@ rhel7cis_section6: true
 
 rhel7cis_selinux_disable: false
 
+rhel7cis_check_for_rhel7_os: true
+
 # These variables correspond with the CIS rule IDs or paragraph numbers defined in
 # the CIS benchmark documents.
 # PLEASE NOTE: These work in coordination with the section # group variables and tags.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
       - ansible_distribution_major_version is version_compare('7', '!=')
   tags:
       - always
+  when: rhel7cis_check_for_rhel7_os|bool
 
 - name: Check ansible version
   fail:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,9 +6,9 @@
   when:
       - ansible_os_family == 'RedHat'
       - ansible_distribution_major_version is version_compare('7', '!=')
+      - rhel7cis_check_for_rhel7_os|bool
   tags:
       - always
-  when: rhel7cis_check_for_rhel7_os|bool
 
 - name: Check ansible version
   fail:


### PR DESCRIPTION
### Changes
- Add flag for allowing users to disable the RHEL7 O/S check.
- Remove trailing whitespaces (text editor does this by default)

### Testing
- Applied this role with the flag set to false and observed that the O/S check was no longer ran.
- Applied this role with the flag set to true and observed the default behaviour of checking for the RHEL7 O/S.

### Context
I've been using a fork of this repository for running CIS benchmarks against Amazon Linux 2 and it works perfectly. I would like to contribute this change back so that if people want to try running this against operating systems that are RHEL like that they're able to. Happy for it to be noted that support is not provided for Amazon Linux 2 in general.