### PR TITLE
updated lockdown audit tool template

### DIFF
--- a/templates/ansible_vars_goss.yml
+++ b/templates/ansible_vars_goss.yml
@@ -318,6 +318,8 @@ rhel7cis_ypbind_required: {{ rhel7cis_ypbind_required }}
 
 # AIDE
 rhel7cis_config_aide: {{ rhel7cis_config_aide }}
+# can check if using service and timer - options: cron or timer
+rhel7cis_aide_checks: cron
 
 # AIDE cron settings
 rhel7cis_aide_cron:
@@ -331,6 +333,7 @@ rhel7cis_aide_cron:
   aide_weekday: '{{ rhel7cis_aide_cron.aide_weekday }}'
 
 # 1.5.1 Bootloader password
+rhel7cis_bootloader_file: {{ bootloader_file }}
 rhel7cis_bootloader_password: {{ rhel7cis_bootloader_password_hash }}
 rhel7cis_set_boot_pass: {{ rhel7cis_set_boot_pass }}
 


### PR DESCRIPTION
Enhanced the options passed to lockdown auditing tool within the template
added cron schedule type and pass the bootloader file for audit

Signed-off-by: Mark Bolwell <mark.bollyuk@gmail.com>