### PR TITLE
empty group for disable su command

### DIFF
--- a/tasks/section_5/cis_5.6.yml
+++ b/tasks/section_5/cis_5.6.yml
@@ -1,5 +1,5 @@
 ---
-
+ 
 - name: "SCORED | 5.6 | PATCH | Ensure access to the su command is restricted"
   block:
   - name: "SCORED | 5.6 | PATCH | Ensure access to the su command is restricted | Setting pm_wheel to use_uid"
@@ -7,18 +7,18 @@
       state: present
       dest: /etc/pam.d/su
       regexp: '^(#)?auth\s+required\s+pam_wheel\.so'
-      line: 'auth           required        pam_wheel.so use_uid'
+      line: 'auth            required        pam_wheel.so use_uid group=sugroup'
     when:
     - rhel7cis_rule_5_6
     tags:
     - level1
     - patch
     - rule_5.6
-
-  - name: "SCORED | 5.6 | PATCH | Ensure access to the su command is restricted | wheel group contains root"
-    user:
-      name: root
-      groups: wheel
+ 
+  - name: "SCORED | 5.6 | PATCH | Ensure access to the su command is restricted | create sugroup"
+    group:
+      name: sugroup
+      state: present
   when:
   - rhel7cis_rule_5_6
   tags:


### PR DESCRIPTION
The "su" command was not restricted as "group=sugroup" was missing in pam config.
Also creating new empty group will also disable "su" command for root user.

Signed-off-by: Ives Hotz <git@hotzenplotz.ch>