### PR TITLE
added sugroup variable and defaults

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,9 @@
 
 - 1.5.2 moved grub capture to prelim
 
+- 5.6 ability to supply an sugroup rather than default to wheel
+  - thanks to ihotz #234
+
 ## Whats new in 1.0.2
 
 - renamed goss library and aligned ansible.cfg file

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -517,6 +517,11 @@ rhel7cis_futurepwchgdate_autofix: true
 # 5.4.2
 rhel7cis_int_gid: 1000
 
+# 5.6 Group to be used for su
+# this group needs to exists groups will not be created for remediation this is considered sys admins
+
+# rhel7cis_sugroup: sugroup
+
 ## Section6 vars
 
 # RHEL-07_6.1.1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,26 @@
   - rhel7cis_set_boot_pass
   - rhel7cis_rule_1_5_1
 
+- name: "check sugroup exists if used"
+  block:
+  - name: "Check su group exists if defined"
+    command: grep -w "{{ rhel7cis_sugroup }}" /etc/group
+    register: sugroup_exists
+    changed_when: false
+    failed_when: sugroup_exists.rc >= 2
+    tags:
+    - skip_ansible_lint
+
+  - name: Check sugroup if defined exists before continuing
+    assert:
+      that: sugroup_exists.rc == '0'
+      msg: "The variable rhel7cis_sugroup is defined but does not exist please rectify" 
+  when:
+  - rhel7cis_sugroup is defined
+  - rhel7cis_rule_5_6
+  tags:
+  - rule_5.6
+
 - include: check_prereqs.yml
   tags:
   - always

--- a/tasks/section_5/cis_5.6.yml
+++ b/tasks/section_5/cis_5.6.yml
@@ -2,12 +2,12 @@
 
 - name: "SCORED | 5.6 | PATCH | Ensure access to the su command is restricted"
   block:
-  - name: "SCORED | 5.6 | PATCH | Ensure access to the su command is restricted | Setting pm_wheel to use_uid"
+  - name: "SCORED | 5.6 | PATCH | Ensure access to the su command is restricted | Setting pam_wheel to use_uid"
     lineinfile:
       state: present
       dest: /etc/pam.d/su
       regexp: '^(#)?auth\s+required\s+pam_wheel\.so'
-      line: 'auth           required        pam_wheel.so use_uid'
+      line: 'auth            required        pam_wheel.so use_uid {% if rhel7cis_sugroup is defined %}group={{ rhel7cis_sugroup }}{% endif %}'
     when:
     - rhel7cis_rule_5_6
     tags:
@@ -18,7 +18,7 @@
   - name: "SCORED | 5.6 | PATCH | Ensure access to the su command is restricted | wheel group contains root"
     user:
       name: root
-      groups: wheel
+      groups: "{{ rhel7cis_sugroup | default('wheel') }}"
   when:
   - rhel7cis_rule_5_6
   tags:

--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -428,6 +428,10 @@ rhel7cis_ssh_weak_kex:
 rhel7cis_ssh_aliveinterval: "300"
 rhel7cis_ssh_countmax: "3"
 
+{% if rhel7cis_sugroup is defined %}
+rhel7cis_sugroup: {{ rhel7cis_sugroup }}
+{% endif %}
+
 ## PAM
 rhel7cis_pam_password:
   - minclass = 4

--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -428,9 +428,8 @@ rhel7cis_ssh_weak_kex:
 rhel7cis_ssh_aliveinterval: "300"
 rhel7cis_ssh_countmax: "3"
 
-{% if rhel7cis_sugroup is defined %}
-rhel7cis_sugroup: {{ rhel7cis_sugroup }}
-{% endif %}
+rhel7cis_sugroup: {{ rhel7cis_sugroup| default('wheel') }}
+
 
 ## PAM
 rhel7cis_pam_password:


### PR DESCRIPTION
#234 allow group to be specified in pam - defaults to wheel existing users require no changes
ensure new options are passed to audit role via template
Other improvements in variable usage and re-enable all sections as default for standalone

Signed-off-by: Mark Bolwell <mark.bollyuk@gmail.com>