### PR TITLE
Allow toggling OS check

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,8 @@ rhel7cis_section4: true
 rhel7cis_section5: true
 rhel7cis_section6: true
 
+# Disable/Enable OS check
+rhel7cis_os_check: true
 
 ## Python Binary
 ## This is used for python3 Installations where python2 OS modules are used in ansible

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
   when:
   - ansible_os_family == 'RedHat'
   - ansible_distribution_major_version is version_compare('7', '!=')
+  - rhel7cis_os_check
   tags:
   - always
 


### PR DESCRIPTION
Signed-off-by: Michael Hsu <cheeto@gmail.com>

I use this ansible role to harden Amazon Linux 2 ami's which are based on RHEL7.  It'd be great to be able to just toggle the OS check so I can use the role without modification.