### PR TITLE
Update cis_3.1.x.yml

### DIFF
--- a/tasks/section_3/cis_3.1.x.yml
+++ b/tasks/section_3/cis_3.1.x.yml
@@ -5,7 +5,6 @@
       dest: /etc/default/grub
       regexp: '(^GRUB_CMDLINE_LINUX\s*\=\s*)(?:")(.+)(?<!ipv6.disable=1)(?:")'
       replace: '\1"\2 ipv6.disable=1"'
-      follow: yes
   notify: grub2cfg
   when:
       - not rhel7cis_ipv6_required


### PR DESCRIPTION
follow is removed from module replace inn Ansible 2.5

**Overall Review of Changes:**
removed the follow parameter

**Issue Fixes:**
-
**Enhancements:**
none

**How has this been tested?:**
If follow directive is not removed; Ansible throws an error:
```
TASK [ans_al_role_rhel7_cis : 3.1.1 | L2 | PATCH | Disable IPv6 | grub] ****************************************************************
fatal: [fnalg-pv-smtp02.finance.cloud]: FAILED! => changed=false
  msg: 'Unsupported parameters for (replace) module: follow. Supported parameters include: path (dest, destfile, name), seuser, group, encoding, unsafe_writes, selevel, after, setype, replace, serole, mode, owner, regexp, validate, backup, attributes (attr), before.'
```
After removing the follow parameter; playbook runs this task just fine.
