### PR TITLE
typo in module

### DIFF
--- a/tasks/section_1/cis_1.4.x.yml
+++ b/tasks/section_1/cis_1.4.x.yml
@@ -61,7 +61,7 @@
         lineinfile:
             dest: /usr/lib/systemd/system/rescue.service
             regexp: '/sbin/sulogin'
-            line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default'
+            line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
   when:
       - rhel7cis_rule_1_4_3
   tags:

--- a/tasks/section_5/cis_5.3.x.yml
+++ b/tasks/section_5/cis_5.3.x.yml
@@ -242,7 +242,7 @@
   lineinfile:
       state: present
       dest: /etc/ssh/sshd_config
-      regexp: '^Cipherss'
+      regexp: '^Ciphers'
       line: "Ciphers {{ rhel7cis_sshd['ciphers'] }}"
   notify:
       - restart sshd


### PR DESCRIPTION
**Overall Review of Changes:**
Fixed a typo for SSHd config 5.3.x.yml
quoting on 1.4.x.yml

**Issue Fixes:**
typo fixes
corrected quoting


**How has this been tested?:**
I got a double line, after changing; the original line got replaced now.
