### PR TITLE
Fixed a buggy condition in rule 2.2.1.1

### DIFF
--- a/tasks/section_2/cis_2.2.1.x.yml
+++ b/tasks/section_2/cis_2.2.1.x.yml
@@ -48,7 +48,8 @@
       state: stopped
       enabled: no
   when:
-      - rhel7cis_time_synchronization == "ntp" and "'chrony' in ansible_facts.packages"
+      - "'chrony' in ansible_facts.packages"
+      - rhel7cis_time_synchronization == "ntp"
       - rhel7cis_rule_2_2_1_1
       - not rhel7cis_system_is_container
   tags:


### PR DESCRIPTION
Due to the quotes, the condition after the `and` is never truly evaluated.
Instead it is always considered True, which causes erroneous behavior.