### PR TITLE
Fixed rule 3.5.1.4.

### DIFF
--- a/tasks/section_3/cis_3.5.1.x.yml
+++ b/tasks/section_3/cis_3.5.1.x.yml
@@ -47,6 +47,7 @@
       name: firewalld
       state: started
       enabled: true
+      masked: false
   when:
       - rhel7cis_rule_3_5_1_4
   tags:


### PR DESCRIPTION
Sometimes the firewalld service won't start because it's masked and causes an
error. This little fix ensures firewalld is unmasked before starting/enabling it.