### PR TITLE
Ablity to change audit environment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -562,7 +562,12 @@ rhel7cis_dotperm_ansiblemanaged: true
 
 # RHEL-07-6.2.18 Clear users from shadow group
 rhel7cis_remove_shadow_grp_usrs: true
+
 #### Goss Configuration Settings ####
+audit_run_script_environment:
+    AUDIT_BIN: "{{ audit_bin }}"
+    AUDIT_FILE: 'goss.yml'
+    AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
 
 ### Goss binary settings ###
 goss_version:

--- a/tasks/post_remediation_audit.yml
+++ b/tasks/post_remediation_audit.yml
@@ -1,7 +1,10 @@
 ---
 
 - name: "Post Audit | Run post_remediation {{ benchmark }} audit"
-  shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g {{ group_names }}"
+  shell: "{{ audit_conf_dir }}run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g {{ group_names }}"
+  environment: "{{ audit_run_script_environment|default({}) }}"
+  changed_when: audit_run_post_remediation.rc == 0
+  register: audit_run_post_remediation
   vars:
       warn: false
 

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -3,79 +3,79 @@
 - name: Audit Binary Setup | Setup the LE audit
   include_tasks: LE_audit_setup.yml
   when:
-  - setup_audit
+      - setup_audit
   tags:
-  - setup_audit
+      - setup_audit
 
 - name: "Pre Audit Setup | Ensure {{ audit_conf_dir }} exists"
   file:
-    path: "{{ audit_conf_dir }}"
-    state: directory
-    mode: '0755'
+      path: "{{ audit_conf_dir }}"
+      state: directory
+      mode: '0755'
 
 - name: Pre Audit Setup | If using git for content set up
   block:
-  - name: Pre Audit Setup | Install git (rh8 python3)
-    package:
-      name: git
-      state: present
-    when: ansible_distribution_major_version == '8'
-  
-  - name: Pre Audit Setup | Install git (rh7 python2)
-    package:
-      name: git
-      state: present
-    vars:
-      ansible_python_interpreter: "{{ python2_bin }}"
-    when: ansible_distribution_major_version == '7'
+      - name: Pre Audit Setup | Install git (rh8 python3)
+        package:
+            name: git
+            state: present
+        when: ansible_distribution_major_version == '8'
 
-  - name: Pre Audit Setup | retrieve audit content files from git
-    git:
-      repo: "{{ audit_file_git }}"
-      dest: "{{ audit_conf_dir }}"
-      version: "{{ audit_git_version }}"
+      - name: Pre Audit Setup | Install git (rh7 python2)
+        package:
+            name: git
+            state: present
+        vars:
+            ansible_python_interpreter: "{{ python2_bin }}"
+        when: ansible_distribution_major_version == '7'
+
+      - name: Pre Audit Setup | retrieve audit content files from git
+        git:
+            repo: "{{ audit_file_git }}"
+            dest: "{{ audit_conf_dir }}"
+            version: "{{ audit_git_version }}"
   when:
   - audit_content == 'git'
 
 - name: Pre Audit Setup | copy to audit content files to server
   copy:
-    src: "{{ audit_local_copy }}"
-    dest: "{{ audit_conf_dir }}"
-    mode: 0644
+      src: "{{ audit_local_copy }}"
+      dest: "{{ audit_conf_dir }}"
+      mode: 0644
   when:
-  - audit_content == 'copy'
+      - audit_content == 'copy'
 
 - name: Pre Audit Setup | get audit content from url
   get_url:
-    url: "{{ audit_files_url }}"
-    dest: "{{ audit_conf_dir }}"
+      url: "{{ audit_files_url }}"
+      dest: "{{ audit_conf_dir }}"
   when:
-  - audit_content == 'get_url'
+      - audit_content == 'get_url'
 
 - name: Pre Audit Setup | Check Goss is available
   block:
-  - name: Pre Audit Setup | Check for goss file
-    stat:
-      path: "{{ audit_bin }}"
-    register: goss_available
-  
-  - name: Pre Audit Setup | If audit ensure goss is available
-    assert:
-      msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
-    when: 
-    - not goss_available.stat.exists
+      - name: Pre Audit Setup | Check for goss file
+        stat:
+            path: "{{ audit_bin }}"
+        register: goss_available
+      
+      - name: Pre Audit Setup | If audit ensure goss is available
+        assert:
+            msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
+        when: 
+            - not goss_available.stat.exists
   when:
   - run_audit
 
 - name: Pre Audit Setup | Copy ansible default vars values to test audit
   template:
-    src: ansible_vars_goss.yml.j2
-    dest: "{{ audit_vars_path }}"
-    mode: 0600
+      src: ansible_vars_goss.yml.j2
+      dest: "{{ audit_vars_path }}"
+      mode: 0600
   when:
-  - run_audit
+      - run_audit
   tags:
-  - goss_template
+      - goss_template
   
 - name: "Pre Audit | Run pre_remediation {{ benchmark }} audit"
   shell: "{{ audit_conf_dir }}run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g {{ group_names }}"
@@ -87,28 +87,28 @@
 
 - name: Pre Audit | Capture audit data if json format
   block:
-  - name: "capture data {{ pre_audit_outfile }}"
-    command: "cat {{ pre_audit_outfile }}"
-    register: pre_audit
-    changed_when: false 
-    
-  - name: Pre Audit | Capture pre-audit result
-    set_fact: 
-        pre_audit_summary: "{{ pre_audit.stdout | from_json |json_query(summary) }}"
-    vars:
-        summary: 'summary."summary-line"'
-    when:
-        - audit_format == "json"
+      - name: "capture data {{ pre_audit_outfile }}"
+        command: "cat {{ pre_audit_outfile }}"
+        register: pre_audit
+        changed_when: false 
+        
+      - name: Pre Audit | Capture pre-audit result
+        set_fact: 
+            pre_audit_summary: "{{ pre_audit.stdout | from_json |json_query(summary) }}"
+        vars:
+            summary: 'summary."summary-line"'
+  when:
+      - audit_format == "json"
 
 - name: Pre Audit | Capture audit data if documentation format
   block:
-  - name: "capture data {{ pre_audit_outfile }}"
-    command: "tail -2 {{ pre_audit_outfile }}"
-    register: pre_audit
-    changed_when: false
+      - name: "capture data {{ pre_audit_outfile }}"
+        command: "tail -2 {{ pre_audit_outfile }}"
+        register: pre_audit
+        changed_when: false
 
-  - name: Pre Audit | Capture pre-audit result
-    set_fact:
-        pre_audit_summary: "{{ pre_audit.stdout_lines }}"
-    when:
-        - audit_format == "documentation"
+      - name: Pre Audit | Capture pre-audit result
+        set_fact:
+            pre_audit_summary: "{{ pre_audit.stdout_lines }}"
+  when:
+      - audit_format == "documentation"

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -3,109 +3,112 @@
 - name: Audit Binary Setup | Setup the LE audit
   include_tasks: LE_audit_setup.yml
   when:
-      - setup_audit
+  - setup_audit
   tags:
-      - setup_audit
+  - setup_audit
 
 - name: "Pre Audit Setup | Ensure {{ audit_conf_dir }} exists"
   file:
-      path: "{{ audit_conf_dir }}"
-      state: directory
-      mode: '0755'
+    path: "{{ audit_conf_dir }}"
+    state: directory
+    mode: '0755'
 
 - name: Pre Audit Setup | If using git for content set up
   block:
-      - name: Pre Audit Setup | Install git (rh8 python3)
-        package:
-          name: git
-          state: present
-        when: ansible_distribution_major_version == '8'
-      
-      - name: Pre Audit Setup | Install git (rh7 python2)
-        package:
-          name: git
-          state: present
-        vars:
-          ansible_python_interpreter: "{{ python2_bin }}"
-        when: ansible_distribution_major_version == '7'
+  - name: Pre Audit Setup | Install git (rh8 python3)
+    package:
+      name: git
+      state: present
+    when: ansible_distribution_major_version == '8'
+  
+  - name: Pre Audit Setup | Install git (rh7 python2)
+    package:
+      name: git
+      state: present
+    vars:
+      ansible_python_interpreter: "{{ python2_bin }}"
+    when: ansible_distribution_major_version == '7'
 
-      - name: Pre Audit Setup | retrieve audit content files from git
-        git:
-          repo: "{{ audit_file_git }}"
-          dest: "{{ audit_conf_dir }}"
-          version: "{{ audit_git_version }}"
+  - name: Pre Audit Setup | retrieve audit content files from git
+    git:
+      repo: "{{ audit_file_git }}"
+      dest: "{{ audit_conf_dir }}"
+      version: "{{ audit_git_version }}"
   when:
-      - audit_content == 'git'
+  - audit_content == 'git'
 
 - name: Pre Audit Setup | copy to audit content files to server
   copy:
-      src: "{{ audit_local_copy }}"
-      dest: "{{ audit_conf_dir }}"
-      mode: 0644
+    src: "{{ audit_local_copy }}"
+    dest: "{{ audit_conf_dir }}"
+    mode: 0644
   when:
-      - audit_content == 'copy'
+  - audit_content == 'copy'
 
 - name: Pre Audit Setup | get audit content from url
   get_url:
-      url: "{{ audit_files_url }}"
-      dest: "{{ audit_conf_dir }}"
+    url: "{{ audit_files_url }}"
+    dest: "{{ audit_conf_dir }}"
   when:
-      - audit_content == 'get_url'
+  - audit_content == 'get_url'
 
 - name: Pre Audit Setup | Check Goss is available
   block:
-      - name: Pre Audit Setup | Check for goss file
-        stat:
-          path: "{{ audit_bin }}"
-        register: goss_available
-      
-      - name: Pre Audit Setup | If audit ensure goss is available
-        assert:
-          msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
-        when: 
-        - not goss_available.stat.exists
+  - name: Pre Audit Setup | Check for goss file
+    stat:
+      path: "{{ audit_bin }}"
+    register: goss_available
+  
+  - name: Pre Audit Setup | If audit ensure goss is available
+    assert:
+      msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
+    when: 
+    - not goss_available.stat.exists
   when:
-      - run_audit
+  - run_audit
 
 - name: Pre Audit Setup | Copy ansible default vars values to test audit
   template:
-      src: ansible_vars_goss.yml.j2
-      dest: "{{ audit_vars_path }}"
-      mode: 0600
+    src: ansible_vars_goss.yml.j2
+    dest: "{{ audit_vars_path }}"
+    mode: 0600
   when:
-      - run_audit
+  - run_audit
   tags:
-      - goss_template
+  - goss_template
   
 - name: "Pre Audit | Run pre_remediation {{ benchmark }} audit"
-  shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g {{ group_names }}"
+  shell: "{{ audit_conf_dir }}run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g {{ group_names }}"
+  environment: "{{ audit_run_script_environment|default({}) }}"
+  changed_when: audit_run_pre_remediation.rc == 0
+  register: audit_run_pre_remediation
   vars:
       warn: false
 
 - name: Pre Audit | Capture audit data if json format
   block:
-      - name: "capture data {{ pre_audit_outfile }}"
-        command: "cat {{ pre_audit_outfile }}"
-        register: pre_audit
-        changed_when: false 
-        
-      - name: Pre Audit | Capture pre-audit result
-        set_fact: 
-            pre_audit_summary: "{{ pre_audit.stdout | from_json |json_query(summary) }}"
-        vars:
-            summary: 'summary."summary-line"'
-  when:
-      - audit_format == "json"
+  - name: "capture data {{ pre_audit_outfile }}"
+    command: "cat {{ pre_audit_outfile }}"
+    register: pre_audit
+    changed_when: false 
+    
+  - name: Pre Audit | Capture pre-audit result
+    set_fact: 
+        pre_audit_summary: "{{ pre_audit.stdout | from_json |json_query(summary) }}"
+    vars:
+        summary: 'summary."summary-line"'
+    when:
+        - audit_format == "json"
 
 - name: Pre Audit | Capture audit data if documentation format
   block:
-    - name: "capture data {{ pre_audit_outfile }}"
-      command: "tail -2 {{ pre_audit_outfile }}"
-      register: pre_audit
-      changed_when: false
+  - name: "capture data {{ pre_audit_outfile }}"
+    command: "tail -2 {{ pre_audit_outfile }}"
+    register: pre_audit
+    changed_when: false
 
-    - name: Pre Audit | Capture pre-audit result
-      set_fact:
-          pre_audit_summary: "{{ pre_audit.stdout_lines }}"
-  when:
-    - audit_format == "documentation"
+  - name: Pre Audit | Capture pre-audit result
+    set_fact:
+        pre_audit_summary: "{{ pre_audit.stdout_lines }}"
+    when:
+        - audit_format == "documentation"


### PR DESCRIPTION
Signed-off-by: Mark Bolwell <mark.bollyuk@gmail.com>

**Overall Review of Changes:**
Ability to change the environment used by the audit component if adopting certain mountpoint settings breaks it,

Thanks to @pavloos in RH8
https://github.com/ansible-lockdown/RHEL8-CIS/issues/186


**How has this been tested?:**
manually and other platforms

