### PR TITLE
Task validation fixes (by Steampunk Spotter)

### DIFF
--- a/tasks/check_prereqs.yml
+++ b/tasks/check_prereqs.yml
@@ -2,7 +2,7 @@
 
 - name: "PREREQ | Check required packages installed | Python2"
   ansible.builtin.package:
-      list: "{{ item }}"
+      name: "{{ item }}"
       state: present
   loop:
       - rpm-python

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -66,9 +66,8 @@
 
       - name: Pre Audit Setup | If audit ensure goss is available
         ansible.builtin.assert:
+            that: goss_available.stat.exists
             msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
-        when:
-            - not goss_available.stat.exists
   when:
       - run_audit
 

--- a/tasks/section_1/cis_1.2.x.yml
+++ b/tasks/section_1/cis_1.2.x.yml
@@ -74,7 +74,7 @@
       - rule_1.2.4
 
 - name: "1.2.5 | PATCH | Disable the rhnsd Daemon"
-  ansible.builtin.service:
+  ansible.builtin.systemd:
       name: rhnsd
       state: stopped
       enabled: false

--- a/tasks/section_5/cis_5.5.x.yml
+++ b/tasks/section_5/cis_5.5.x.yml
@@ -3,7 +3,7 @@
 - name: "5.5.2 | PATCH | Ensure system accounts are secured"
   block:
       - name: "5.5.2 | PATCH | Ensure system accounts are secured | Set nologin"
-        user:
+        ansible.builtin.user:
             name: "{{ item.id }}"
             shell: /usr/sbin/nologin
         loop: "{{ rhel7cis_passwd }}"
@@ -19,7 +19,7 @@
             - item.shell != "      /usr/sbin/nologin"
 
       - name: "5.5.2 | PATCH | Ensure system accounts are secured | Lock accounts"
-        user:
+        ansible.builtin.user:
             name: "{{ item.id }}"
             password_lock: true
         loop: "{{ rhel7cis_passwd }}"
@@ -42,7 +42,7 @@
       - rule_5.5.2
 
 - name: "5.5.3 | PATCH | Ensure default group for the root account is GID 0"
-  shell: usermod -g 0 root
+  ansible.builtin.shell: usermod -g 0 root
   changed_when: false
   failed_when: false
   when:

--- a/tasks/section_5/cis_5.7.yml
+++ b/tasks/section_5/cis_5.7.yml
@@ -10,7 +10,7 @@
             line: 'auth            required        pam_wheel.so use_uid {% if rhel7cis_sugroup is defined %}group={{ rhel7cis_sugroup }}{% endif %}'
 
       - name: "5.7 | PATCH | Ensure access to the su command is restricted | wheel group contains root"
-        ansible.builtin.group:
+        ansible.builtin.user:
             name: root
             groups: "{{ rhel7cis_sugroup }}"
         when:

--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -10,7 +10,7 @@
             - rhel7cis_passwd | selectattr('password', '!=', 'x')
 
       - name: "6.2.1 | PATCH | Ensure accounts in /etc/passwd use shadow passwords | Good News"
-        debug:
+        ansible.builtin.debug:
             msg: "Good News!!  No Unshadowed passwords have been found"
         when: rhel7_6_2_1_shadow is not changed
   when:


### PR DESCRIPTION
**Overall Review of Changes:**
These changes will try to correct some errors and warnings within Ansible tasks that I have come across when running some checks with [Steampunk Spotter](https://steampunk.si/spotter/). 

**Enhancements:**
These changes fix the following errors detected by the Spotter CLI:

```console
(.venv) user@ubuntu:~/RHEL7-CIS$ spotter scan --ansible-version 2.12 --display-level error .
Scanning...success. ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
------------------------------------------------------------------------
tasks/check_prereqs.yml:3:3: ERROR: [E001] list is not a valid parameter in module ansible.builtin.package.
tasks/check_prereqs.yml:3:3: ERROR: [E005] name is a required parameter in module ansible.builtin.package.
tasks/post.yml:4:3: ERROR: [E001] autoremove is not a valid parameter in module ansible.builtin.package.
tasks/post.yml:4:3: ERROR: [E005] name is a required parameter in module ansible.builtin.package.
tasks/post.yml:4:3: ERROR: [E005] state is a required parameter in module ansible.builtin.package.
tasks/pre_remediation_audit.yml:67:9: ERROR: [E005] that is a required parameter in module ansible.builtin.assert.
tasks/section_1/cis_1.2.x.yml:76:3: ERROR: [E001] masked is not a valid parameter in module ansible.builtin.service.
tasks/section_5/cis_5.7.yml:12:9: ERROR: [E001] groups is not a valid parameter in module ansible.builtin.group.
------------------------------------------------------------------------
Spotter took 2.068 s to scan your input.
It resulted in 9 error(s), 162 warning(s) and 181 hint(s).
Overall status: ERROR
```

**How has this been tested?:**
N/A