### PR TITLE
Audit only and lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ uses:
 pre-commit run
 ```
 
-## Credits
+## Credits and Thanks
 
-This repo originated from work done by [Sam Doran](https://github.com/samdoran/ansible-role-stig)
+Massive thanks to the fantastic community and all its members.
+
+This includes a huge thanks and credit to the original authors and maintainers.
+
+Josh Springer, Daniel Shepherd, Bas Meijeri, James Cassell, Mike Renfro, DFed, George Nalen, Mark Bolwell

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,25 +26,46 @@ python2_bin: /bin/python2.7
 benchmark: RHEL7-CIS
 benchmark_version: v3.1.1
 
-#### Basic external goss audit enablement settings ####
-#### Precise details - per setting can be found at the bottom of this file ####
+##########################################
+### Goss is required on the remote host ###
+## Refer to vars/auditd.yml for any other settings ##
 
-### Goss is required on the remote host
+# Allow audit to setup the requirements including installing git (if option chosen and downloading and adding goss binary to system)
 setup_audit: false
-# How to retrive goss
+
+# enable audits to run - this runs the audit and get the latest content
+run_audit: false
+
+# Only run Audit do not remediate
+audit_only: false
+# As part of audit_only
+# This will enable files to be copied back to control node
+fetch_audit_files: false
+# Path to copy the files to will create dir structure
+audit_capture_files_dir: /some/location to copy to on control node
+
+# How to retrieve audit binary
 # Options are copy or download - detailed settings at the bottom of this file
 # you will need to access to either github or the file already dowmloaded
-get_goss_file: download
+get_audit_binary_method: download
+
+## if get_audit_binary_method - copy the following needs to be updated for your environment
+## it is expected that it will be copied from somewhere accessible to the control node
+## e.g copy from ansible control node to remote host
+audit_bin_copy_location: /some/accessible/path
 
 # how to get audit files onto host options
-# options are git/copy/get_url
+# options are git/copy/get_url other e.g. if you wish to run from already downloaded conf
 audit_content: git
 
-# Timeout for those cmds that take longer to run where timeout set
-audit_cmd_timeout: 30000
+# archive or copy:
+audit_conf_copy: "some path to copy from"
 
-# enable audits to run - this  runs the audit and get the latest content
-run_audit: false
+# get_url:
+audit_files_url: "some url maybe s3?"
+
+# Run heavy tests - some tests can have more impact on a system enabling these can have greater impact on a system
+audit_run_heavy_tests: true
 
 ### End Goss enablements ####
 #### Detailed settings found at the end of this document ####
@@ -565,55 +586,3 @@ rhel7cis_dotperm_ansiblemanaged: true
 
 # RHEL-07-6.2.18 Clear users from shadow group
 rhel7cis_remove_shadow_grp_usrs: true
-
-#### Goss Configuration Settings ####
-audit_run_script_environment:
-    AUDIT_BIN: "{{ audit_bin }}"
-    AUDIT_FILE: 'goss.yml'
-    AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
-
-### Goss binary settings ###
-goss_version:
-    release: v0.3.23
-    checksum: 'sha256:9e9f24e25f86d6adf2e669a9ffbe8c3d7b9b439f5f877500dea02ba837e10e4d'
-audit_bin_path: /usr/local/bin/
-audit_bin: "{{ audit_bin_path }}goss"
-audit_format: json
-
-# if get_goss_file == download change accordingly
-goss_url: "https://github.com/goss-org/goss/releases/download/{{ goss_version.release }}/goss-linux-amd64"
-
-## if get_goss_file - copy the following needs to be updated for your environment
-## it is expected that it will be copied from somewhere accessible to the control node
-## e.g copy from ansible control node to remote host
-copy_goss_from_path: /some/accessible/path
-
-### Goss Audit Benchmark file ###
-## managed by the control audit_content
-# git
-audit_file_git: "https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
-audit_git_version: "benchmark_{{ benchmark_version }}"
-
-# copy:
-audit_local_copy: "some path to copy from"
-
-# get_url:
-audit_files_url: "some url maybe s3?"
-
-# Where the goss audit configuration will be stored
-audit_files: "/opt/{{ benchmark }}-Audit/"
-
-## Goss configuration information
-# Where the goss configs and outputs are stored
-audit_out_dir: '/opt'
-audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}-Audit/"
-pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_hostname }}-{{ benchmark }}_pre_scan_{{ ansible_date_time.epoch }}.{{ audit_format }}"
-post_audit_outfile: "{{ audit_out_dir }}/{{ ansible_hostname }}-{{ benchmark }}_post_scan_{{ ansible_date_time.epoch }}.{{ audit_format }}"
-
-## The following should not need changing
-goss_file: "{{ audit_conf_dir }}goss.yml"
-audit_vars_path: "{{ audit_conf_dir  }}/vars/{{ ansible_hostname }}.yml"
-audit_results: |
-      The pre remediation results are: {{ pre_audit_summary }}.
-      The post remediation results are: {{ post_audit_summary }}.
-      Full breakdown can be found in {{ audit_out_dir }}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 
 galaxy_info:
-    author: "Sam Doran, Josh Springer, Daniel Shepherd, Bas Meijeri, James Cassell, Mike Renfro, DFed, Mark Bolwell, George Nalen"
+    author: "MindPoint group"
     description: "Apply the CIS RHEL7 role"
     company: "MindPoint Group"
     license: MIT

--- a/tasks/LE_audit_setup.yml
+++ b/tasks/LE_audit_setup.yml
@@ -1,22 +1,34 @@
 ---
 
-- name: Download goss binary
-  ansible.builtin.get_url:
-      url: "{{ goss_url }}"
-      dest: "{{ audit_bin }}"
-      owner: root
-      group: root
-      checksum: "{{ goss_version.checksum }}"
-      mode: 0555
-  when:
-      - get_goss_file == 'download'
+- name: Pre Audit Setup | Set audit package name
+  block:
+      - name: Pre Audit Setup | Set audit package name | 64bit
+        ansible.builtin.set_fact:
+            audit_pkg_arch_name: AMD64
+        when: ansible_facts.machine == "x86_64"
 
-- name: Copy goss binary
-  ansible.builtin.copy:
-      src: "{{ copy_goss_from_path }}"
+      - name: Pre Audit Setup | Set audit package name | ARM64
+        ansible.builtin.set_fact:
+            audit_pkg_arch_name: ARM64
+        when: ansible_facts.machine == "arm64"
+
+- name: Pre Audit Setup | Download audit binary
+  ansible.builtin.get_url:
+      url: "{{ audit_bin_url }}{{ audit_pkg_arch_name }}"
       dest: "{{ audit_bin }}"
-      mode: 0555
+      owner: root
+      group: root
+      checksum: "{{ audit_bin_version[audit_pkg_arch_name + '_checksum'] }}"
+      mode: '0555'
+  when:
+      - get_audit_binary_method == 'download'
+
+- name: Pre Audit Setup | Copy audit binary
+  ansible.builtin.copy:
+      src: "{{ audit_bin_copy_location }}"
+      dest: "{{ audit_bin }}"
+      mode: '0555'
       owner: root
       group: root
   when:
-      - get_goss_file == 'copy'
+      - get_audit_binary_method == 'copy'

--- a/tasks/audit_only.yml
+++ b/tasks/audit_only.yml
@@ -1,0 +1,30 @@
+---
+
+- name: Audit_Only | Create local Directories for hosts
+  ansible.builtin.file:
+      mode: '0755'
+      path: "{{ audit_capture_files_dir }}/{{ inventory_hostname }}"
+      recurse: true
+      state: directory
+  when: fetch_audit_files
+  delegate_to: localhost
+  become: false
+
+- name: Audit_only | Get audits from systems and put in group dir
+  ansible.builtin.fetch:
+      dest: "{{ audit_capture_files_dir }}/{{ inventory_hostname }}/"
+      flat: true
+      mode: '0644'
+      src: "{{ pre_audit_outfile }}"
+  when: fetch_audit_files
+
+- name: Audit_only | Show Audit Summary
+  when:
+      - audit_only
+  ansible.builtin.debug:
+      msg: "The Audit results are: {{ pre_audit_summary }}."
+
+- name: Audit_only | Stop Playbook Audit Only selected
+  when:
+      - audit_only
+  ansible.builtin.meta: end_play

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,8 @@
       - rule_5.6
 
 - name: Import prereq checks
-  ansible.builtin.import_tasks: check_prereqs.yml
+  ansible.builtin.import_tasks:
+      file: check_prereqs.yml
   tags:
       - always
       - prereqs
@@ -75,15 +76,28 @@
       - always
 
 - name: Import preliminary tasks
-  ansible.builtin.import_tasks: prelim.yml
+  ansible.builtin.import_tasks:
+      file: prelim.yml
   tags:
       - prelim_tasks
       - always
 
-- name: Import pre remediation audit
-  ansible.builtin.import_tasks: pre_remediation_audit.yml
+- name: Include audit specific variables
+  ansible.builtin.include_vars:
+      file: audit.yml
   when:
+      - run_audit or audit_only
+      - setup_audit
+  tags:
+      - setup_audit
       - run_audit
+
+- name: Include pre-remediation audit tasks
+  ansible.builtin.import_tasks:
+      file: pre_remediation_audit.yml
+  when:
+      - run_audit or audit_only
+      - setup_audit
   tags:
       - run_audit
 
@@ -94,48 +108,56 @@
       - always
 
 - name: Include OS specific variables
-  ansible.builtin.include_vars: "{{ ansible_distribution }}.yml"
+  ansible.builtin.include_vars:
+      file: "{{ ansible_distribution }}.yml"
   tags:
       - always
 
 - name: Run parse etc password for user variables
-  ansible.builtin.import_tasks: parse_etc_password.yml
+  ansible.builtin.import_tasks:
+      file: parse_etc_password.yml
   when:
       - rhel7cis_section5 or
         rhel7cis_section6
 
 - name: Import section 1 tasks
-  ansible.builtin.import_tasks: section_1/main.yml
+  ansible.builtin.import_tasks:
+      file: section_1/main.yml
   when: rhel7cis_section1
   tags:
       - rhel7cis_section1
 
 - name: Import section 2 tasks
-  ansible.builtin.import_tasks: section_2/main.yml
+  ansible.builtin.import_tasks:
+      file: section_2/main.yml
   tags:
       - rhel7cis_section2
   when: rhel7cis_section2
 
 - name: Import section 3 tasks
-  ansible.builtin.import_tasks: section_3/main.yml
+  ansible.builtin.import_tasks:
+      file: section_3/main.yml
   when: rhel7cis_section3
   tags:
       - rhel7cis_section3
 
 - name: Import section 4 tasks
-  ansible.builtin.import_tasks: section_4/main.yml
+  ansible.builtin.import_tasks:
+      file: section_4/main.yml
   when: rhel7cis_section4
   tags:
       - rhel7cis_section4
 
 - name: Import section 5 tasks
-  ansible.builtin.import_tasks: section_5/main.yml
+  ansible.builtin.import_tasks:
+      file: section_5/main.yml
   when: rhel7cis_section5
   tags:
       - rhel7cis_section5
 
 - name: Import section 6 tasks
-  ansible.builtin.import_tasks: section_6/main.yml
+  ansible.builtin.import_tasks:
+      file: section_6/main.yml
   when: rhel7cis_section6
   tags:
       - rhel7cis_section6
@@ -144,16 +166,16 @@
   ansible.builtin.meta: flush_handlers
 
 - name: Post Task
-  ansible.builtin.import_tasks: post.yml
+  ansible.builtin.import_tasks:
+      file: post.yml
   tags:
       - post_tasks
       - always
 
-- name: Import post remediation task
-  ansible.builtin.import_tasks: post_remediation_audit.yml
+- name: Run post audit
+  ansible.builtin.import_tasks:
+      file: post_remediation_audit.yml
   when:
-      - run_audit
-  tags:
       - run_audit
 
 - name: Show Audit Summary

--- a/tasks/post_remediation_audit.yml
+++ b/tasks/post_remediation_audit.yml
@@ -1,24 +1,28 @@
 ---
 
-- name: "Post Audit | Run post_remediation {{ benchmark }} audit"
-  ansible.builtin.shell: "{{ audit_conf_dir }}run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g {{ group_names }}"
-  environment: "{{ audit_run_script_environment | default({}) }}"
-  changed_when: false
-  register: audit_run_post_remediation
+- name: Post Audit | Run post_remediation {{ benchmark }} audit
+  ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g \"{{ group_names }}\""
+  changed_when: true
+  environment:
+      AUDIT_BIN: "{{ audit_bin }}"
+      AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
+      AUDIT_FILE: goss.yml
 
 - name: Post Audit | ensure audit files readable by users
   ansible.builtin.file:
       path: "{{ item }}"
-      mode: 0644
+      mode: '0644'
       state: file
   loop:
       - "{{ post_audit_outfile }}"
       - "{{ pre_audit_outfile }}"
 
 - name: Post Audit | Capture audit data if json format
+  when:
+      - audit_format == "json"
   block:
-      - name: "capture data {{ post_audit_outfile }}"
-        ansible.builtin.command: "cat {{ post_audit_outfile }}"
+      - name: capture data {{ post_audit_outfile }}
+        ansible.builtin.shell: cat {{ post_audit_outfile }}
         register: post_audit
         changed_when: false
 
@@ -26,19 +30,17 @@
         ansible.builtin.set_fact:
             post_audit_summary: "{{ post_audit.stdout | from_json | json_query(summary) }}"
         vars:
-            summary: 'summary."summary-line"'
-  when:
-      - audit_format == "json"
+            summary: summary."summary-line"
 
 - name: Post Audit | Capture audit data if documentation format
+  when:
+      - audit_format == "documentation"
   block:
-      - name: "Post Audit | capture data {{ post_audit_outfile }}"
-        ansible.builtin.command: "tail -2 {{ post_audit_outfile }}"
+      - name: Post Audit | capture data {{ post_audit_outfile }}
+        ansible.builtin.shell: tail -2 {{ post_audit_outfile }}
         register: post_audit
         changed_when: false
 
       - name: Post Audit | Capture post-audit result
         ansible.builtin.set_fact:
             post_audit_summary: "{{ post_audit.stdout_lines }}"
-  when:
-      - audit_format == "documentation"

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -1,63 +1,58 @@
 ---
 
-- name: Audit Binary Setup | Setup the LE audit
-  ansible.builtin.include_tasks: LE_audit_setup.yml
+- name: Pre Audit Setup | Setup the LE audit
   when:
       - setup_audit
   tags:
       - setup_audit
+  ansible.builtin.include_tasks: LE_audit_setup.yml
 
-- name: "Pre Audit Setup | Ensure {{ audit_conf_dir }} exists"
+- name: Pre Audit Setup | Ensure {{ audit_conf_dir }} exists
   ansible.builtin.file:
       path: "{{ audit_conf_dir }}"
       state: directory
       mode: '0755'
 
 - name: Pre Audit Setup | If using git for content set up
+  when:
+      - audit_content == 'git'
   block:
-      - name: Pre Audit Setup | Install git (rh8 python3)
+      - name: Pre Audit Setup | Install git
         ansible.builtin.package:
             name: git
             state: present
-        register: git_audit
-        when: ansible_distribution_major_version == '8'
 
-      - name: Pre Audit Setup | Install git (rh7 python2)
-        ansible.builtin.package:
-            name: git
-            state: present
-        register: git_audit
-        vars:
-            ansible_python_interpreter: "{{ python2_bin }}"
-        when: ansible_distribution_major_version == '7'
-
-      - name: Pre Audit Setup | retrieve audit content files from git
+      - name: Pre Audit Setup | Retrieve audit content files from git
         ansible.builtin.git:
             repo: "{{ audit_file_git }}"
             dest: "{{ audit_conf_dir }}"
             version: "{{ audit_git_version }}"
-  when:
-      - audit_content == 'git'
 
-- name: Pre Audit Setup | copy to audit content files to server
-  ansible.builtin.copy:
-      src: "{{ audit_local_copy }}"
-      dest: "{{ audit_conf_dir }}"
-      mode: 0644
+- name: Pre Audit Setup | Copy to audit content files to server
   when:
       - audit_content == 'copy'
+  ansible.builtin.copy:
+      src: "{{ audit_local_copy }}"
+      dest: "{{ audit_conf_dest }}"
+      mode: preserve
 
-- name: Pre Audit Setup | get audit content from url
+- name: Pre Audit Setup | Unarchive audit content files on server
+  when:
+      - audit_content == 'archived'
+  ansible.builtin.unarchive:
+      src: "{{ audit_conf_copy  }}"
+      dest: "{{ audit_conf_dir }}"
+
+- name: Pre Audit Setup | Get audit content from url
+  when:
+      - audit_content == 'get_url'
   ansible.builtin.get_url:
       url: "{{ audit_files_url }}"
       dest: "{{ audit_conf_dir }}"
-      owner: root
-      group: root
-      mode: 0755
-  when:
-      - audit_content == 'get_url'
 
 - name: Pre Audit Setup | Check Goss is available
+  when:
+      - run_audit
   block:
       - name: Pre Audit Setup | Check for goss file
         ansible.builtin.stat:
@@ -65,32 +60,36 @@
         register: goss_available
 
       - name: Pre Audit Setup | If audit ensure goss is available
+        when:
+            - not goss_available.stat.exists
         ansible.builtin.assert:
-            that: goss_available.stat.exists
             msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
-  when:
-      - run_audit
 
 - name: Pre Audit Setup | Copy ansible default vars values to test audit
+  tags:
+      - goss_template
+      - run_audit
+  when:
+      - run_audit
   ansible.builtin.template:
       src: ansible_vars_goss.yml.j2
       dest: "{{ audit_vars_path }}"
-      mode: 0600
-  when:
-      - run_audit
-  tags:
-      - goss_template
+      mode: '0600'
 
-- name: "Pre Audit | Run pre_remediation {{ benchmark }} audit"
-  ansible.builtin.shell: "{{ audit_conf_dir }}run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g {{ group_names }}"
-  environment: "{{ audit_run_script_environment | default({}) }}"
-  changed_when: false
-  register: audit_run_pre_remediation
+- name: Pre Audit | Run pre_remediation {{ benchmark }} audit
+  ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g \"{{ group_names }}\""
+  changed_when: true
+  environment:
+      AUDIT_BIN: "{{ audit_bin }}"
+      AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
+      AUDIT_FILE: goss.yml
 
 - name: Pre Audit | Capture audit data if json format
+  when:
+      - audit_format == "json"
   block:
-      - name: "capture data {{ pre_audit_outfile }}"
-        ansible.builtin.command: "cat {{ pre_audit_outfile }}"
+      - name: capture data {{ pre_audit_outfile }}
+        ansible.builtin.shell: cat {{ pre_audit_outfile }}
         register: pre_audit
         changed_when: false
 
@@ -98,19 +97,22 @@
         ansible.builtin.set_fact:
             pre_audit_summary: "{{ pre_audit.stdout | from_json | json_query(summary) }}"
         vars:
-            summary: 'summary."summary-line"'
-  when:
-      - audit_format == "json"
+            summary: summary."summary-line"
 
 - name: Pre Audit | Capture audit data if documentation format
+  when:
+      - audit_format == "documentation"
   block:
-      - name: "capture data {{ pre_audit_outfile }}"
-        ansible.builtin.command: "tail -2 {{ pre_audit_outfile }}"
+      - name: Pre Audit | Capture data {{ pre_audit_outfile }} | documentation format
+        ansible.builtin.shell: tail -2 {{ pre_audit_outfile }}
         register: pre_audit
         changed_when: false
 
-      - name: Pre Audit | Capture pre-audit result
+      - name: Pre Audit | Capture pre-audit result | documentation format
         ansible.builtin.set_fact:
             pre_audit_summary: "{{ pre_audit.stdout_lines }}"
+
+- name: Audit_Only | Run Audit Only
   when:
-      - audit_format == "documentation"
+      - audit_only
+  ansible.builtin.import_tasks: audit_only.yml

--- a/tasks/section_1/main.yml
+++ b/tasks/section_1/main.yml
@@ -1,33 +1,43 @@
 ---
 
 - name: "SECTION | 1.1.1 | FileSystem Configurations"
-  ansible.builtin.import_tasks: cis_1.1.1.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_1.1.1.x.yml
 
 - name: "SECTION | 1.1 | Partition Configurations"
-  ansible.builtin.import_tasks: cis_1.1.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_1.1.x.yml
 
 - name: "SECTION | 1.2 | Configure Software Updates"
-  ansible.builtin.import_tasks: cis_1.2.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_1.2.x.yml
 
 - name: "SECTION | 1.3 | Filesystem Integrity"
-  ansible.builtin.import_tasks: cis_1.3.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_1.3.x.yml
   when: rhel7cis_config_aide
 
 - name: "SECTION | 1.4 | Secure Boot Settings"
-  ansible.builtin.import_tasks: cis_1.4.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_1.4.x.yml
 
 - name: "SECTION | 1.5 | Additional Process Hardening"
-  ansible.builtin.import_tasks: cis_1.5.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_1.5.x.yml
 
 - name: "SECTION | 1.6 | Mandatory Access Control"
-  ansible.builtin.import_tasks: cis_1.6.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_1.6.x.yml
   when: not rhel7cis_selinux_disable
 
 - name: "SECTION | 1.7 | Warning Banners"
-  ansible.builtin.import_tasks: cis_1.7.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_1.7.x.yml
 
 - name: "SECTION | 1.8 | GDM Login"
-  ansible.builtin.import_tasks: cis_1.8.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_1.8.x.yml
 
 - name: "SECTION | 1.9 | Updated and Patches"
-  ansible.builtin.import_tasks: cis_1.9.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_1.9.x.yml

--- a/tasks/section_2/main.yml
+++ b/tasks/section_2/main.yml
@@ -1,16 +1,21 @@
 ---
 
 - name: "SECTION | 2.1 | inetd Services"
-  ansible.builtin.import_tasks: cis_2.1.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_2.1.x.yml
 
 - name: "SECTION | 2.2.1 | Time Synchronization"
-  ansible.builtin.import_tasks: cis_2.2.1.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_2.2.1.x.yml
 
 - name: "SECTION | 2.2 | Special Purpose Services"
-  ansible.builtin.import_tasks: cis_2.2.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_2.2.x.yml
 
 - name: "SECTION | 2.3 | Service Clients"
-  ansible.builtin.import_tasks: cis_2.3.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_2.3.x.yml
 
 - name: "SECTION | 2.4 | Nonessential Services"
-  ansible.builtin.import_tasks: cis_2.4.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_2.4.x.yml

--- a/tasks/section_3/main.yml
+++ b/tasks/section_3/main.yml
@@ -1,26 +1,32 @@
 ---
 
 - name: "SECTION | 3.1 | Disable unused network protocols and devices"
-  ansible.builtin.import_tasks: cis_3.1.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_3.1.x.yml
 
 - name: "SECTION | 3.2 | Network Parameters (Host Only)"
-  ansible.builtin.import_tasks: cis_3.2.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_3.2.x.yml
 
 - name: "SECTION | 3.3 | Network Parameters (Host and Router)"
-  ansible.builtin.import_tasks: cis_3.3.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_3.3.x.yml
 
 - name: "SECTION | 3.4 | Uncommon Network Protocols"
-  ansible.builtin.import_tasks: cis_3.4.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_3.4.x.yml
 
 - name: "SECTION | 3.5.1 | Configure firewalld"
-  ansible.builtin.import_tasks: cis_3.5.1.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_3.5.1.x.yml
   when:
       - rhel7cis_firewall == "firewalld"
   tags:
       - firewalld
 
 - name: "SECTION | 3.5.2 | Configure nftables"
-  ansible.builtin.import_tasks: cis_3.5.2.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_3.5.2.x.yml
   when:
       - rhel7cis_firewall == "nftables"
   tags:
@@ -29,16 +35,19 @@
 - name: "SECTION | 3.5.3.x.x | Configure iptables"
   block:
       - name: "SECTION | 3.5.3.1.x | Configure iptables"
-        ansible.builtin.import_tasks: cis_3.5.3.1.x.yml
+        ansible.builtin.import_tasks:
+            file: cis_3.5.3.1.x.yml
       - name: "SECTION | 3.5.3.2.x | Configure iptables"
-        ansible.builtin.import_tasks: cis_3.5.3.2.x.yml
+        ansible.builtin.import_tasks:
+            file: cis_3.5.3.2.x.yml
   when:
       - rhel7cis_firewall == "iptables"
   tags:
       - iptables
 
 - name: "SECTION | 3.5.3.3.x | Configure ip6tables"
-  ansible.builtin.import_tasks: cis_3.5.3.3.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_3.5.3.3.x.yml
   when:
       - not rhel7cis_ipv6_required
       - rhel7cis_firewall == "iptables"

--- a/tasks/section_4/main.yml
+++ b/tasks/section_4/main.yml
@@ -1,16 +1,21 @@
 ---
 
 - name: "SECTION | 4.1| Configure System Accounting (auditd)"
-  ansible.builtin.import_tasks: cis_4.1.1.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_4.1.1.x.yml
 
 - name: "SECTION | 4.1.2.x| Configure Data Retention"
-  ansible.builtin.import_tasks: cis_4.1.2.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_4.1.2.x.yml
 
 - name: "SECTION | 4.2.x| Configure Logging"
-  ansible.builtin.import_tasks: cis_4.2.1.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_4.2.1.x.yml
 
 - name: "SECTION | 4.2.2.x| Configure journald"
-  ansible.builtin.import_tasks: cis_4.2.2.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_4.2.2.x.yml
 
 - name: "SECTION | 4.2.x | logfile configuration"
-  ansible.builtin.import_tasks: cis_4.2.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_4.2.x.yml

--- a/tasks/section_5/main.yml
+++ b/tasks/section_5/main.yml
@@ -1,25 +1,33 @@
 ---
 
 - name: "SECTION | 5.1 | Configure time-based job schedulers"
-  ansible.builtin.import_tasks: cis_5.1.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_5.1.x.yml
 
 - name: "SECTION | 5.2 | Configure Sudo"
-  ansible.builtin.import_tasks: cis_5.2.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_5.2.x.yml
 
 - name: "SECTION | 5.3 | Configure SSH Server"
-  ansible.builtin.import_tasks: cis_5.3.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_5.3.x.yml
 
 - name: "SECTION | 5.4 | Configure PAM"
-  ansible.builtin.import_tasks: cis_5.4.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_5.4.x.yml
 
 - name: "SECTION | 5.5.1 | Set Shadow Password Suite Parameters"
-  ansible.builtin.import_tasks: cis_5.5.1.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_5.5.1.x.yml
 
 - name: "SECTION | 5.5 | User Accounts and Environment"
-  ansible.builtin.import_tasks: cis_5.5.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_5.5.x.yml
 
 - name: "SECTION | 5.6 | User Accounts and Environment"
-  ansible.builtin.import_tasks: cis_5.6.yml
+  ansible.builtin.import_tasks:
+      file: cis_5.6.yml
 
 - name: "SECTION | 5.7 | User Accounts and Environment"
-  ansible.builtin.import_tasks: cis_5.7.yml
+  ansible.builtin.import_tasks:
+      file: cis_5.7.yml

--- a/tasks/section_6/main.yml
+++ b/tasks/section_6/main.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "SECTION | 6.1 | System File Permissions"
-  ansible.builtin.import_tasks: cis_6.1.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_6.1.x.yml
 
 - name: "SECTION | 6.2 | User and Group Settings"
-  ansible.builtin.import_tasks: cis_6.2.x.yml
+  ansible.builtin.import_tasks:
+      file: cis_6.2.x.yml

--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -24,7 +24,7 @@ rhel7cis_selinux_state: {{ rhel7cis_selinux_state }}
 rhel7cis_level1: true
 rhel7cis_level2: true
 # to enable rules that may have IO impact on a system e.g. full filesystem scans or CPU heavy
-run_heavy_tests: true
+run_heavy_tests: {{ audit_run_heavy_tests }}
 
 rhel7cis_legacy_boot: {{ rhel7cis_legacy_boot }}
 

--- a/vars/audit.yml
+++ b/vars/audit.yml
@@ -1,0 +1,39 @@
+---
+
+# Timeout for those cmds that take longer to run where timeout set
+audit_cmd_timeout: 120000
+
+# if get_audit_binary_method == download change accordingly
+audit_bin_url: "https://github.com/goss-org/goss/releases/download/{{ audit_bin_version.release }}/goss-linux-"
+
+### Goss Audit Benchmark file ###
+## managed by the control audit_content
+# git
+audit_file_git: "https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
+audit_git_version: "benchmark_{{ benchmark_version }}"
+
+## Goss configuration information
+# Where the goss configs and outputs are stored
+audit_out_dir: '/opt'
+# Where the goss audit configuration will be stored
+audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}-Audit"
+
+# If changed these can affect other products
+pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
+post_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_post_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
+
+## The following should not need changing
+
+### Audit binary settings ###
+audit_bin_version:
+    release: v0.3.23
+    AMD64_checksum: 'sha256:9e9f24e25f86d6adf2e669a9ffbe8c3d7b9b439f5f877500dea02ba837e10e4d'
+audit_bin_path: /usr/local/bin/
+audit_bin: "{{ audit_bin_path }}goss"
+audit_format: json
+
+audit_vars_path: "{{ audit_conf_dir }}/vars/{{ ansible_facts.hostname }}.yml"
+audit_results: |
+      The pre remediation results are: {{ pre_audit_summary }}.
+      The post remediation results are: {{ post_audit_summary }}.
+      Full breakdown can be found in {{ audit_out_dir }}


### PR DESCRIPTION
**Overall Review of Changes:**
Add audit_only option
galaxy_ng fixes
lint

**Enhancements:**

audit_only: now a variable option to run audit with ansible settings only without remediation
meta updated to allow new galaxy_ng changes

**How has this been tested?:**
manually for audit_only and remediation
